### PR TITLE
Fix/go tabled benchmarks

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -208,7 +208,7 @@ function extractGoResult(output: string): BenchmarkResult[] {
     // Example:
     //   BenchmarkFib20-8           30000             41653 ns/op
     //   BenchmarkDoWithConfigurer1-8            30000000                42.3 ns/op
-    const reExtract = /^(Benchmark\w+)(-\d+)?\s+(\d+)\s+([0-9.]+)\s+(.+)$/;
+    const reExtract = /^(Benchmark\w+\/?.*?)(-\d+)?\s+(\d+)\s+([0-9.]+)\s+(.+)$/;
 
     for (const line of lines) {
         const m = line.match(reExtract);

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -208,7 +208,7 @@ function extractGoResult(output: string): BenchmarkResult[] {
     // Example:
     //   BenchmarkFib20-8           30000             41653 ns/op
     //   BenchmarkDoWithConfigurer1-8            30000000                42.3 ns/op
-    const reExtract = /^(Benchmark\w+(?:\/?[\w\(\)$%^&*-]*?)*?)(-\d+)?\s+(\d+)\s+([0-9.]+)\s+(.+)$/;
+    const reExtract = /^(Benchmark\w+(?:\/?[\w()$%^&*-]*?)*?)(-\d+)?\s+(\d+)\s+([0-9.]+)\s+(.+)$/;
 
     for (const line of lines) {
         const m = line.match(reExtract);

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -208,7 +208,7 @@ function extractGoResult(output: string): BenchmarkResult[] {
     // Example:
     //   BenchmarkFib20-8           30000             41653 ns/op
     //   BenchmarkDoWithConfigurer1-8            30000000                42.3 ns/op
-    const reExtract = /^(Benchmark\w+(?:\/?[\w$%^&*-]*?)*?)(-\d+)?\s+(\d+)\s+([0-9.]+)\s+(.+)$/;
+    const reExtract = /^(Benchmark\w+(?:\/?[\w\(\)$%^&*-]*?)*?)(-\d+)?\s+(\d+)\s+([0-9.]+)\s+(.+)$/;
 
     for (const line of lines) {
         const m = line.match(reExtract);

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -208,7 +208,7 @@ function extractGoResult(output: string): BenchmarkResult[] {
     // Example:
     //   BenchmarkFib20-8           30000             41653 ns/op
     //   BenchmarkDoWithConfigurer1-8            30000000                42.3 ns/op
-    const reExtract = /^(Benchmark\w+\/?.*?)(-\d+)?\s+(\d+)\s+([0-9.]+)\s+(.+)$/;
+    const reExtract = /^(Benchmark\w+(?:\/?[\w$%^&*-]*?)*?)(-\d+)?\s+(\d+)\s+([0-9.]+)\s+(.+)$/;
 
     for (const line of lines) {
         const m = line.match(reExtract);

--- a/test/data/extract/go_output.txt
+++ b/test/data/extract/go_output.txt
@@ -1,6 +1,8 @@
 goos: darwin
 goarch: amd64
-BenchmarkFib10-8   	 5000000	       325 ns/op
-BenchmarkFib20   	   30000	     40537.123 ns/op
+BenchmarkFib10-8   		 					5000000		325 ns/op
+BenchmarkFib20  	 	   					30000		40537.123 ns/op
+BenchmarkFib/my_tabled_benchmark_-_10-8    	5000000		325 ns/op
+BenchmarkFib/my_tabled_benchmark_-_20		30000		40537.123 ns/op
 PASS
 ok  	_/Users/rhayasd/Develop/github.com/rhysd/github-action-benchmark/examples/go	3.614s

--- a/test/data/extract/go_output.txt
+++ b/test/data/extract/go_output.txt
@@ -4,5 +4,6 @@ BenchmarkFib10-8   		 					5000000		325 ns/op
 BenchmarkFib20  	 	   					30000		40537.123 ns/op
 BenchmarkFib/my_tabled_benchmark_-_10-8    	5000000		325 ns/op
 BenchmarkFib/my_tabled_benchmark_-_20		30000		40537.123 ns/op
+BenchmarkFib/my/tabled/benchmark_-_20		30001		40537.456 ns/op
 PASS
 ok  	_/Users/rhayasd/Develop/github.com/rhysd/github-action-benchmark/examples/go	3.614s

--- a/test/extract.ts
+++ b/test/extract.ts
@@ -102,6 +102,18 @@ describe('extractResult()', function() {
                     value: 40537.123,
                     extra: '30000 times',
                 },
+				{
+                    name: 'BenchmarkFib/my_tabled_benchmark_-_10',
+                    unit: 'ns/op',
+                    value: 325,
+                    extra: '5000000 times\n8 procs',
+                },
+                {
+                    name: 'BenchmarkFib/my_tabled_benchmark_-_20',
+                    unit: 'ns/op',
+                    value: 40537.123,
+                    extra: '30000 times',
+                },
             ],
         },
         {

--- a/test/extract.ts
+++ b/test/extract.ts
@@ -114,6 +114,12 @@ describe('extractResult()', function() {
                     value: 40537.123,
                     extra: '30000 times',
                 },
+                {
+                    name: 'BenchmarkFib/my/tabled/benchmark_-_20',
+                    unit: 'ns/op',
+                    value: 40537.456,
+                    extra: '30001 times',
+                },
             ],
         },
         {

--- a/test/extract.ts
+++ b/test/extract.ts
@@ -102,7 +102,7 @@ describe('extractResult()', function() {
                     value: 40537.123,
                     extra: '30000 times',
                 },
-				{
+                {
                     name: 'BenchmarkFib/my_tabled_benchmark_-_10',
                     unit: 'ns/op',
                     value: 325,


### PR DESCRIPTION
Extended regex to also include tabled benchmarks.

Fixes #31 