### PR TITLE
fetch gh-pages branch using github token

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -87,3 +87,15 @@ export async function pull(token: string | undefined, branch: string, ...options
 
     return cmd(...args);
 }
+
+export async function fetch(token: string | undefined, branch: string, ...options: string[]): Promise<string> {
+    core.debug(`Executing 'git fetch' for branch '${branch}' with token and options '${options.join(' ')}'`);
+
+    const remote = token !== undefined ? getRemoteUrl(token) : 'origin';
+    let args = ['fetch', remote, `${branch}:${branch}`];
+    if (options.length > 0) {
+        args = args.concat(options);
+    }
+
+    return cmd(...args);
+}

--- a/src/write.ts
+++ b/src/write.ts
@@ -430,9 +430,9 @@ async function writeBenchmarkToGitHubPagesWithRetry(
 }
 
 async function writeBenchmarkToGitHubPages(bench: Benchmark, config: Config): Promise<Benchmark | null> {
-    const { ghPagesBranch, skipFetchGhPages } = config;
+    const { ghPagesBranch, skipFetchGhPages, githubToken } = config;
     if (!skipFetchGhPages) {
-        await git.cmd('fetch', 'origin', `${ghPagesBranch}:${ghPagesBranch}`);
+        await git.fetch(githubToken, ghPagesBranch);
     }
     await git.cmd('switch', ghPagesBranch);
     try {

--- a/test/write.ts
+++ b/test/write.ts
@@ -45,7 +45,7 @@ class FakedOctokit {
     }
 }
 
-type GitFunc = 'cmd' | 'push' | 'pull';
+type GitFunc = 'cmd' | 'push' | 'pull' | 'fetch';
 class GitSpy {
     history: [GitFunc, unknown[]][];
     pushFailure: null | string;
@@ -122,6 +122,10 @@ mock('../src/git', {
     },
     async pull(...args: unknown[]) {
         gitSpy.call('pull', args);
+        return '';
+    },
+    async fetch(...args: unknown[]) {
+        gitSpy.call('fetch', args);
         return '';
     },
 });
@@ -924,7 +928,7 @@ describe('writeBenchmark()', function() {
             const autoPush = cfg.autoPush ?? true;
             const skipFetch = cfg.skipFetch ?? false;
             const hist: Array<[GitFunc, unknown[]] | undefined> = [
-                skipFetch ? undefined : ['cmd', ['fetch', 'origin', 'gh-pages:gh-pages']],
+                skipFetch ? undefined : ['fetch', [token, 'gh-pages']],
                 ['cmd', ['switch', 'gh-pages']],
                 fetch ? ['pull', [token, 'gh-pages']] : undefined,
                 ['cmd', ['add', path.join(dir, 'data.js')]],


### PR DESCRIPTION
This patch introduces the function git.fetch analogue to git.pull which uses the github token (if present) to authenticate the git fetch request. This enables using github-action-benchmark with private repositories (see #19).