### PR TITLE
Add PerformanceEntry benchmark tool support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,35 @@ jobs:
           skip-fetch-gh-pages: true
           fail-on-alert: true
       - run: node ./scripts/ci_validate_modification.js before_data.js 'Benchmark.js Benchmark'
+  jsperformanceentry:
+    name: Run JsPerformanceEntry benchmark example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+      - run: npm ci
+      - run: npm run build
+      - name: Save previous data.js
+        run: |
+          git fetch origin gh-pages
+          git checkout gh-pages
+          cp ./dev/bench/data.js before_data.js
+          git checkout -
+      - name: Run benchmark
+        run: cd examples/jsperformanceentry && npm install && node bench.js | tee output.txt
+      - name: Store benchmark result
+        uses: ./
+        with:
+          name: JsPerformanceEntry Benchmark
+          tool: 'jsperformanceentry'
+          output-file-path: examples/jsperformanceentry/output.txt
+          skip-fetch-gh-pages: true
+          fail-on-alert: true
+      - run: node ./scripts/ci_validate_modification.js before_data.js 'JsPerformanceEntry Benchmark'
   pytest-benchmark:
     name: Run Pytest benchmark example
     runs-on: ubuntu-latest

--- a/.github/workflows/jsperformanceentry.yml
+++ b/.github/workflows/jsperformanceentry.yml
@@ -1,0 +1,29 @@
+name: JsPerformanceEntry Example
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  benchmark:
+    name: Run JsPerformanceEntry benchmark example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - name: Run JsPerformanceEntry
+        run: cd examples/jsperformanceentry && npm install && node bench.js | tee output.txt
+      - name: Store JsPerformanceEntry result
+        uses: rhysd/github-action-benchmark@v1
+        with:
+          name: JsPerformanceEntry Benchmark
+          tool: 'jsperformanceentry'
+          output-file-path: examples/jsperformanceentry/output.txt
+          # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
+          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          auto-push: true
+          # Show alert with commit comment on detecting possible performance regression
+          alert-threshold: '200%'
+          comment-on-alert: true
+          fail-on-alert: true
+          alert-comment-cc-users: '@gsouquet'

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This action currently supports the following tools:
 - [`cargo bench`][cargo-bench] for Rust projects
 - `go test -bench` for Go projects
 - [benchmark.js][benchmarkjs] for JavaScript/TypeScript projects
+- [JsPerformanceEntry][[jsperformanceentry]] for JavaScript/TypeScript projects
 - [pytest-benchmark][] for Python projects with [pytest][]
 - [Google Benchmark Framework][google-benchmark] for C++ projects
 - [Catch2][catch2] for C++ projects
@@ -34,14 +35,15 @@ Multiple languages in the same repository are supported for polyglot projects.
 Example projects for each language are in [examples/](./examples) directory. Live example workflow
 definitions are in [.github/workflows/](./.github/workflows) directory. Live workflows are:
 
-| Language     | Workflow                                                                                | Example Project                                |
-|--------------|-----------------------------------------------------------------------------------------|------------------------------------------------|
-| Rust         | [![Rust Example Workflow][rust-badge]][rust-workflow-example]                           | [examples/rust](./examples/rust)               |
-| Go           | [![Go Example Workflow][go-badge]][go-workflow-example]                                 | [examples/go](./examples/go)                   |
-| JavaScript   | [![JavaScript Example Workflow][benchmarkjs-badge]][benchmarkjs-workflow-example]       | [examples/benchmarkjs](./examples/benchmarkjs) |
-| Python       | [![pytest-benchmark Example Workflow][pytest-benchmark-badge]][pytest-workflow-example] | [examples/pytest](./examples/pytest)           |
-| C++          | [![C++ Example Workflow][cpp-badge]][cpp-workflow-example]                              | [examples/cpp](./examples/cpp)                 |
-| C++ (Catch2) | [![C++ Catch2 Example Workflow][catch2-badge]][catch2-workflow-example]                 | [examples/catch2](./examples/catch2)           |
+| Language     | Workflow                                                                                          | Example Project                                              |
+|--------------|---------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| Rust         | [![Rust Example Workflow][rust-badge]][rust-workflow-example]                                     | [examples/rust](./examples/rust)                             |
+| Go           | [![Go Example Workflow][go-badge]][go-workflow-example]                                           | [examples/go](./examples/go)                                 |
+| JavaScript   | [![JavaScript Example Workflow][benchmarkjs-badge]][benchmarkjs-workflow-example]                 | [examples/benchmarkjs](./examples/benchmarkjs)               |
+| JavaScript   | [![JsPerformance Example Workflow][jsperformanceentry-badge]][benchmarkjs-workflow-example]       | [examples/jsperformanceentry](./examples/jsperformanceentry) |
+| Python       | [![pytest-benchmark Example Workflow][pytest-benchmark-badge]][pytest-workflow-example]           | [examples/pytest](./examples/pytest)                         |
+| C++          | [![C++ Example Workflow][cpp-badge]][cpp-workflow-example]                                        | [examples/cpp](./examples/cpp)                               |
+| C++ (Catch2) | [![C++ Catch2 Example Workflow][catch2-badge]][catch2-workflow-example]                           | [examples/catch2](./examples/catch2)                         |
 
 All benchmark charts from above workflows are gathered in GitHub pages:
 
@@ -300,6 +302,7 @@ and store it to file. Then specify the file path to `output-file-path` input.
 - [`cargo bench` for Rust projects](./examples/rust/README.md)
 - [`go test` for Go projects](./examples/go/README.md)
 - [Benchmark.js for JavaScript/TypeScript projects](./examples/benchmarkjs/README.md)
+- [JsPerformanceEntry for JavaScript/TypeScript projects](./examples/jsperformanceentry/README.md)
 - [pytest-benchmark for Python projects with pytest](./examples/pytest/README.md)
 - [Google Benchmark Framework for C++ projects](./examples/cpp/README.md)
 
@@ -322,7 +325,7 @@ Name of the benchmark. This value must be identical across all benchmarks in you
 - Type: String
 - Default: N/A
 
-Tool for running benchmark. The value must be one of `"cargo"`, `"go"`, `"benchmarkjs"`, `"pytest"`,
+Tool for running benchmark. The value must be one of `"cargo"`, `"go"`, `"benchmarkjs"`, `"jsperformanceentry"`, `"pytest"`,
 `"googlecpp"`, `"catch2"`.
 
 #### `output-file-path` (Required)
@@ -563,12 +566,14 @@ Every release will appear on your GitHub notifications page.
 [rust-badge]: https://github.com/rhysd/github-action-benchmark/workflows/Rust%20Example/badge.svg
 [go-badge]: https://github.com/rhysd/github-action-benchmark/workflows/Go%20Example/badge.svg
 [benchmarkjs-badge]: https://github.com/rhysd/github-action-benchmark/workflows/Benchmark.js%20Example/badge.svg
+[jsperformanceentry-badge]: https://github.com/rhysd/github-action-benchmark/workflows/JsPerformanceEntry%20Example/badge.svg
 [pytest-benchmark-badge]: https://github.com/rhysd/github-action-benchmark/workflows/Python%20Example%20with%20pytest/badge.svg
 [cpp-badge]: https://github.com/rhysd/github-action-benchmark/workflows/C%2B%2B%20Example/badge.svg
 [catch2-badge]: https://github.com/rhysd/github-action-benchmark/workflows/Catch2%20C%2B%2B%20Example/badge.svg
 [github-action]: https://github.com/features/actions
 [cargo-bench]: https://doc.rust-lang.org/cargo/commands/cargo-bench.html
 [benchmarkjs]: https://benchmarkjs.com/
+[jsperformanceentry]: https://developer.mozilla.org/docs/Web/API/Performance
 [gh-pages]: https://pages.github.com/
 [examples-page]: https://rhysd.github.io/github-action-benchmark/dev/bench/
 [pytest-benchmark]: https://pypi.org/project/pytest-benchmark/
@@ -577,6 +582,7 @@ Every release will appear on your GitHub notifications page.
 [rust-workflow-example]: https://github.com/rhysd/github-action-benchmark/actions?query=workflow%3A%22Rust+Example%22
 [go-workflow-example]: https://github.com/rhysd/github-action-benchmark/actions?query=workflow%3A%22Go+Example%22
 [benchmarkjs-workflow-example]: https://github.com/rhysd/github-action-benchmark/actions?query=workflow%3A%22Benchmark.js+Example%22
+[jsperformanceentry-workflow-example]: https://github.com/rhysd/github-action-benchmark/actions?query=workflow%3A%22JsPerformanceEntry%20Example%22
 [pytest-workflow-example]: https://github.com/rhysd/github-action-benchmark/actions?query=workflow%3A%22Python+Example+with+pytest%22
 [cpp-workflow-example]: https://github.com/rhysd/github-action-benchmark/actions?query=workflow%3A%22C%2B%2B+Example%22
 [catch2-workflow-example]: https://github.com/rhysd/github-action-benchmark/actions?query=workflow%3A%22Catch2+C%2B%2B+Example%22

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: true
     default: 'Benchmark'
   tool:
-    description: 'Tool to use get benchmark output. One of "cargo", "go", "benchmarkjs", "pytest"'
+    description: 'Tool to use get benchmark output. One of "cargo", "go", "benchmarkjs", "jsperformanceentry", "pytest"'
     required: true
   output-file-path:
     description: 'A path to file which contains the benchmark output'

--- a/examples/jsperformanceentry/.gitignore
+++ b/examples/jsperformanceentry/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/package-lock.json

--- a/examples/jsperformanceentry/README.md
+++ b/examples/jsperformanceentry/README.md
@@ -1,0 +1,56 @@
+Node.js example for benchmarking with the [JS performance API](https://developer.mozilla.org/docs/Web/API/Performance)
+======================================================================================================================
+
+- [Workflow for this example](../../.github/workflows/jsperformanceentry.yml)
+- [Action log of this example](#TODO)
+- [Benchmark results on GitHub pages](#TODO)
+
+This directory shows how to use [`github-action-benchmark`](https://github.com/rhysd/github-action-benchmark)
+with [JS performance API](https://developer.mozilla.org/docs/Web/API/Performance).
+
+## Run benchmarks
+
+Documentation for usage of the performance API:
+
+- In a browser context: https://developer.mozilla.org/docs/Web/API/Performance
+- In a Node.js context: https://nodejs.org/api/perf_hooks.html
+
+Prepare script `bench.js` as follows:
+
+e.g.
+
+```javascript
+
+performance.mark('start');
+
+functionToBenchmark(25);
+
+performance.mark('end');
+performance.measure('eventName', 'start', 'end');
+
+const entries = JSON.stringify(performance.getEntriesByType('measure'));
+console.log(entries);
+```
+
+Run the script in workflow:
+
+e.g.
+
+```yaml
+- name: Run benchmark
+  run: node bench.js | tee output.txt
+```
+
+## Process benchmark results
+
+Store the benchmark results with step using the action. Please set `benchmarkjs` to `tool` input.
+
+```yaml
+- name: Store benchmark result
+  uses: rhysd/github-action-benchmark@v1
+  with:
+    tool: 'benchmarkjs'
+    output-file-path: output.txt
+```
+
+Please read ['How to use' section](https://github.com/rhysd/github-action-benchmark#how-to-use) for common usage.

--- a/examples/jsperformanceentry/bench.js
+++ b/examples/jsperformanceentry/bench.js
@@ -1,0 +1,18 @@
+const {
+    performance, // available in web browsers too
+    PerformanceObserver
+} = require('perf_hooks');
+const { fib } = require('./index');
+
+const obs = new PerformanceObserver((perfObserverList, observer) => {
+    const entries = perfObserverList.getEntries();
+    console.log(JSON.stringify(entries));
+    observer.disconnect();
+    process.exit(0);
+});
+obs.observe({ entryTypes: ['measure'] });
+
+performance.mark('start:fib(25)');
+fib(25);
+performance.mark('end:fib(25)');
+performance.measure('fib(25)', 'start:fib(25)', 'end:fib(25)');

--- a/examples/jsperformanceentry/index.js
+++ b/examples/jsperformanceentry/index.js
@@ -1,0 +1,8 @@
+function fib(n) {
+    if (n <= 1) {
+        return 1;
+    }
+    return fib(n - 2) + fib(n - 1);
+}
+
+exports.fib = fib;

--- a/examples/jsperformanceentry/package.json
+++ b/examples/jsperformanceentry/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "performanceentry-example",
+  "private": true,
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Germain Souquet <germain@souquet.com>",
+  "license": "MIT"
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-export type ToolType = 'cargo' | 'go' | 'benchmarkjs' | 'pytest' | 'googlecpp' | 'catch2';
+export type ToolType = 'cargo' | 'go' | 'benchmarkjs' | 'jsperformanceentry' | 'pytest' | 'googlecpp' | 'catch2';
 export interface Config {
     name: string;
     tool: ToolType;
@@ -24,7 +24,15 @@ export interface Config {
     maxItemsInChart: number | null;
 }
 
-export const VALID_TOOLS: ToolType[] = ['cargo', 'go', 'benchmarkjs', 'pytest', 'googlecpp', 'catch2'];
+export const VALID_TOOLS: ToolType[] = [
+    'cargo',
+    'go',
+    'benchmarkjs',
+    'jsperformanceentry',
+    'pytest',
+    'googlecpp',
+    'catch2',
+];
 const RE_UINT = /^\d+$/;
 
 function validateToolType(tool: string): asserts tool is ToolType {

--- a/src/default_index_html.ts
+++ b/src/default_index_html.ts
@@ -114,6 +114,7 @@ export const DEFAULT_INDEX_HTML = String.raw`<!DOCTYPE html>
           cargo: '#dea584',
           go: '#00add8',
           benchmarkjs: '#f1e05a',
+          jsperformanceentry: '#64bd25',
           pytest: '#3572a5',
           googlecpp: '#f34b7d',
           catch2: '#f34b7d',

--- a/src/write.ts
+++ b/src/write.ts
@@ -64,6 +64,8 @@ function biggerIsBetter(tool: ToolType): boolean {
             return false;
         case 'benchmarkjs':
             return true;
+        case 'jsperformanceentry':
+            return false;
         case 'pytest':
             return true;
         case 'googlecpp':

--- a/test/data/extract/jsperformanceentry_output.txt
+++ b/test/data/extract/jsperformanceentry_output.txt
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "fib(10)",
+        "duration": 1234,
+        "startTime": 1337,
+        "entryType": "measure"
+    },
+    {
+        "name": "fib(20)",
+        "duration": 1234,
+        "startTime": 0,
+        "entryType": "measure"
+    }
+]

--- a/test/extract.ts
+++ b/test/extract.ts
@@ -131,6 +131,23 @@ describe('extractResult()', function() {
             ],
         },
         {
+            tool: 'jsperformanceentry',
+            expected: [
+                {
+                    name: 'fib(10)',
+                    unit: 'ms',
+                    value: 1234,
+                    extra: 'type: measure',
+                },
+                {
+                    name: 'fib(20)',
+                    unit: 'ms',
+                    value: 1234,
+                    extra: 'type: measure',
+                },
+            ],
+        },
+        {
             tool: 'pytest',
             expected: [
                 {


### PR DESCRIPTION
First of all thank you for putting this tool together, it will be a huge help to start reporting on performance metric for a project I'm currently working on

This pull request adds support for the JavaScript Performance API that lets you as accurately as possible measure the time a certain operation takes by adding markers in a codebase
The difference with tools like benchmarkjs is that it works across Node.js and web browsers and get be embedded in end to end testing suite ([collecting SPA metrics as an example](https://addyosmani.com/blog/puppeteer-recipes/#spa-performance-metrics))

* Node.js performance API docs: https://nodejs.org/api/perf_hooks.html
* Browser performance API docs: https://developer.mozilla.org/docs/Web/API/Performance

Let me know your thoughts,
Also open to ideas regarding the tool naming as I believe we could find a better one than `jsperformanceentry`