### PR TITLE
fix: allow more test name

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -178,7 +178,7 @@ function extractCargoResult(output: string): BenchmarkResult[] {
     const ret = [];
     // Example:
     //   test bench_fib_20 ... bench:      37,174 ns/iter (+/- 7,527)
-    const reExtract = /^test ([\w/]+)\s+\.\.\. bench:\s+([0-9,]+) ns\/iter \(\+\/- ([0-9,]+)\)$/;
+    const reExtract = /^test (\S+)\s+\.\.\. bench:\s+([0-9,]+) ns\/iter \(\+\/- ([0-9,]+)\)$/;
     const reComma = /,/g;
 
     for (const line of lines) {


### PR DESCRIPTION
Hi! I am using github action for benchmarking! Thanks for the great library.

I am using fixture filenames as benchmark name so they will contain non `\w` in the test name like `fixture.ext`.
Changing `[\w/]` to `\S` allow more names as test.

Example failing case https://github.com/HerringtonDarkholme/vue-compiler/runs/3774871750?check_suite_focus=true