### PR TITLE
Add optional commit SHA in config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ context) properties. Like this:
         "unit": "Megabytes",
         "value": 100,
         "range": "3",
-        "extra": "Value for Tooltip: 25\nOptional Num #2: 100\nAnything Else!",
+        "extra": "Value for Tooltip: 25\nOptional Num #2: 100\nAnything Else!"
     }
 ]
 ```
@@ -469,8 +469,15 @@ with `actions/cache` action. Please read 'Minimal setup' section above.
 
 Max number of data points in a chart for avoiding too busy chart. This value must be unsigned integer
 larger than zero. If the number of benchmark results for some benchmark suite exceeds this value,
-the oldest one will be removed before storing the results to file. By default this value is empty
+the oldest one will be removed before storing the results to file. By default, this value is empty
 which means there is no limit.
+
+#### `commit-sha` (Optional)
+
+- Type: String
+- Default: N/A
+
+The commit SHA to tag the benchmark with. Uses this in place of the payload if provided.
 
 
 ### Action outputs

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,9 @@ inputs:
   max-items-in-chart:
     description: 'Max data points in a benchmark chart to avoid making the chart too busy. Value must be unsigned integer. No limit by default'
     required: false
+  commit-sha:
+    description: 'The commit SHA to tag the benchmark with. If not provided, uses GitHub context.'
+    required: false
 
 runs:
   using: 'node12'

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,7 @@ export interface Config {
     alertCommentCcUsers: string[];
     externalDataJsonPath: string | undefined;
     maxItemsInChart: number | null;
+    commitSha: string | undefined;
 }
 
 export const VALID_TOOLS: ToolType[] = [
@@ -240,6 +241,7 @@ export async function configFromJobInput(): Promise<Config> {
     let externalDataJsonPath: undefined | string = core.getInput('external-data-json-path');
     const maxItemsInChart = getUintInput('max-items-in-chart');
     let failThreshold = getPercentageInput('fail-threshold');
+    const commitSha: string | undefined = core.getInput('commit-sha') || undefined;
 
     validateToolType(tool);
     outputFilePath = await validateOutputFilePath(outputFilePath);
@@ -254,6 +256,9 @@ export async function configFromJobInput(): Promise<Config> {
     }
     if (commentOnAlert) {
         validateGitHubToken('comment-on-alert', githubToken, 'to send commit comment on alert');
+    }
+    if (commitSha) {
+        validateGitHubToken('commit-sha', githubToken, 'to retrieve the commit info');
     }
     validateAlertThreshold(alertThreshold, failThreshold);
     validateAlertCommentCcUsers(alertCommentCcUsers);
@@ -281,5 +286,6 @@ export async function configFromJobInput(): Promise<Config> {
         externalDataJsonPath,
         maxItemsInChart,
         failThreshold,
+        commitSha,
     };
 }

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -202,13 +202,13 @@ function getCommitFromPullRequestPayload(pr: PullRequest): Commit {
     };
 }
 
-async function getCommitFromGitHubAPIRequest(githubToken: string): Promise<Commit> {
+async function getCommitFromGitHubAPIRequest(githubToken: string, commitSha?: string): Promise<Commit> {
     const octocat = new github.GitHub(githubToken);
 
     const { status, data } = await octocat.repos.getCommit({
         owner: github.context.repo.owner,
         repo: github.context.repo.repo,
-        ref: github.context.ref,
+        ref: commitSha || github.context.ref,
     });
 
     if (!(status === 200 || status === 304)) {
@@ -235,7 +235,11 @@ async function getCommitFromGitHubAPIRequest(githubToken: string): Promise<Commi
     };
 }
 
-async function getCommit(githubToken?: string): Promise<Commit> {
+async function getCommit(githubToken?: string, commitSha?: string): Promise<Commit> {
+    if (commitSha && githubToken) {
+        return getCommitFromGitHubAPIRequest(githubToken, commitSha);
+    }
+
     if (github.context.payload.head_commit) {
         return github.context.payload.head_commit;
     }
@@ -564,7 +568,7 @@ function extractCustomBenchmarkResult(output: string): BenchmarkResult[] {
 
 export async function extractResult(config: Config): Promise<Benchmark> {
     const output = await fs.readFile(config.outputFilePath, 'utf8');
-    const { tool, githubToken } = config;
+    const { tool, githubToken, commitSha } = config;
     let benches: BenchmarkResult[];
 
     switch (tool) {
@@ -603,7 +607,7 @@ export async function extractResult(config: Config): Promise<Benchmark> {
         throw new Error(`No benchmark result was found in ${config.outputFilePath}. Benchmark output was '${output}'`);
     }
 
-    const commit = await getCommit(githubToken);
+    const commit = await getCommit(githubToken, commitSha);
 
     return {
         commit,

--- a/test/extract.spec.ts
+++ b/test/extract.spec.ts
@@ -16,7 +16,7 @@ const dummyWebhookPayload = {
 let dummyCommitData = {};
 class DummyGitHub {
     repos = {
-        getCommit: () => {
+        getCommit: async () => {
             return {
                 status: 200,
                 data: dummyCommitData,

--- a/test/write.spec.ts
+++ b/test/write.spec.ts
@@ -202,6 +202,7 @@ describe('writeBenchmark()', function () {
             externalDataJsonPath: dataJson,
             maxItemsInChart: null,
             failThreshold: 2.0,
+            commitSha: undefined,
         };
 
         const savedRepository = gitHubContext.payload.repository;
@@ -885,6 +886,7 @@ describe('writeBenchmark()', function () {
             externalDataJsonPath: undefined,
             maxItemsInChart: null,
             failThreshold: 2.0,
+            commitSha: 'dummy sha',
         };
 
         function gitHistory(


### PR DESCRIPTION
## Description
Allows the user to pass in a commit SHA to use instead of relying on the payload or head commit. The main use-case of this is for workflow dispatch runs where the SHA is provided through an input.

This change should be valid based on https://docs.github.com/en/rest/reference/commits#get-a-commit.