### PR TITLE
Added option to use Rust benchmark names with spaces

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -264,7 +264,7 @@ function extractCargoResult(output: string): BenchmarkResult[] {
     const ret = [];
     // Example:
     //   test bench_fib_20 ... bench:      37,174 ns/iter (+/- 7,527)
-    const reExtract = /^test (\S+)\s+\.\.\. bench:\s+([0-9,]+) ns\/iter \(\+\/- ([0-9,]+)\)$/;
+    const reExtract = /^test (.+)\s+\.\.\. bench:\s+([0-9,]+) ns\/iter \(\+\/- ([0-9,]+)\)$/;
     const reComma = /,/g;
 
     for (const line of lines) {

--- a/test/data/extract/criterion_output.txt
+++ b/test/data/extract/criterion_output.txt
@@ -1,0 +1,14 @@
+WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
+This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.
+
+Gnuplot not found, using plotters backend
+test Create Realm ... bench:         329 ns/iter (+/- 4)
+
+test Symbols (Execution) ... bench:        3268 ns/iter (+/- 47)
+
+test For loop (Execution) ... bench:       12314 ns/iter (+/- 123)
+
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.5s, enable flat sampling, or reduce sample count to 50.
+test Fibonacci (Execution) ... bench:     1672496 ns/iter (+/- 10166)
+

--- a/test/extract.spec.ts
+++ b/test/extract.spec.ts
@@ -74,6 +74,36 @@ describe('extractResult()', function () {
             ],
         },
         {
+            tool: 'cargo',
+            file: 'criterion_output.txt',
+            expected: [
+                {
+                    name: 'Create Realm',
+                    range: '± 4',
+                    unit: 'ns/iter',
+                    value: 329,
+                },
+                {
+                    name: 'Symbols (Execution)',
+                    range: '± 47',
+                    unit: 'ns/iter',
+                    value: 3268,
+                },
+                {
+                    name: 'For loop (Execution)',
+                    range: '± 123',
+                    unit: 'ns/iter',
+                    value: 12314,
+                },
+                {
+                    name: 'Fibonacci (Execution)',
+                    range: '± 10166',
+                    unit: 'ns/iter',
+                    value: 1672496,
+                },
+            ],
+        },
+        {
             tool: 'catch2',
             expected: [
                 {


### PR DESCRIPTION
When using Criterion for Rust benchmarks, you can use any string as a benchmark name, but this action doesn't allow for this option. We have a repo with strings for these benchmark names, and we would need this feature.