### PR TITLE
trim name of benchmark.js output

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -345,7 +345,7 @@ function extractBenchmarkJsResult(output: string): BenchmarkResult[] {
         if (idx === -1) {
             continue;
         }
-        const name = line.slice(0, idx);
+        const name = line.slice(0, idx).trim();
         const rest = line.slice(idx);
 
         const m = rest.match(reExtract);

--- a/test/data/extract/benchmarkjs_output.txt
+++ b/test/data/extract/benchmarkjs_output.txt
@@ -1,4 +1,4 @@
-fib(10) x 1,431,759 ops/sec ±0.74% (93 runs sampled)
+  fib(10) x 1,431,759 ops/sec ±0.74% (93 runs sampled)
 fib(20) x 12,146 ops/sec ±0.32% (96 runs sampled)
 
 this x line should be ignored


### PR DESCRIPTION
For vitest, we plan to use tinybench, a fork of benchmark.js. As such it is potentially adding whitespace at the beginning of the benchmark output. So if you would like to use the benchmark action, it would show whitespace at the beginning of the benchmark name.

I think the minimal invasive way to get both working is by trimming the name.

https://github.com/vitest-dev/vitest/pull/1029