### PR TITLE
feat: add capability to read commit id using git

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,14 @@ larger than zero. If the number of benchmark results for some benchmark suite ex
 the oldest one will be removed before storing the results to file. By default this value is empty
 which means there is no limit.
 
+#### `read-commit-id-from-git` (Optional)
+
+- Type: Boolean
+- Default: `false`
+
+Read the commit id from the workspace. This is useful when you have switched the repository away
+from the commit that started this action.
+
 
 ### Action outputs
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ export interface Config {
     alertCommentCcUsers: string[];
     externalDataJsonPath: string | undefined;
     maxItemsInChart: number | null;
+    readCommitIdFromGit: boolean;
 }
 
 export const VALID_TOOLS = [
@@ -233,6 +234,7 @@ export async function configFromJobInput(): Promise<Config> {
     const alertThreshold = getPercentageInput('alert-threshold');
     const failOnAlert = getBoolInput('fail-on-alert');
     const alertCommentCcUsers = getCommaSeparatedInput('alert-comment-cc-users');
+    const readCommitIdFromGit = getBoolInput('read-commit-id-from-git');
     let externalDataJsonPath: undefined | string = core.getInput('external-data-json-path');
     const maxItemsInChart = getUintInput('max-items-in-chart');
     let failThreshold = getPercentageInput('fail-threshold');
@@ -281,5 +283,6 @@ export async function configFromJobInput(): Promise<Config> {
         externalDataJsonPath,
         maxItemsInChart,
         failThreshold,
+        readCommitIdFromGit,
     };
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -73,6 +73,50 @@ function getCurrentRepoRemoteUrl(token: string): string {
     return getRepoRemoteUrl(token, `${serverName}/${owner}/${repo}`);
 }
 
+export async function readCommitId(...options: string[]): Promise<string> {
+    core.debug(`Executing 'git rev-parse HEAD' with options '${options.join(' ')}'`);
+
+    let args = ['rev-parse', 'HEAD'];
+    if (options.length > 0) {
+        args = args.concat(options);
+    }
+
+    return cmd(options, ...args);
+}
+
+export async function readCommitTimestamp(...options: string[]): Promise<string> {
+    core.debug(`Executing 'git show -s --format=%ci HEAD' with options '${options.join(' ')}'`);
+
+    let args = ['show', '-s', '--format=%ci', 'HEAD'];
+    if (options.length > 0) {
+        args = args.concat(options);
+    }
+
+    return cmd(options, ...args);
+}
+
+export async function readCommitEmail(...options: string[]): Promise<string> {
+    core.debug(`Executing 'git show -s --format='%ae' HEAD' with options '${options.join(' ')}'`);
+
+    let args = ['show', '-s', '--format=%ae', 'HEAD'];
+    if (options.length > 0) {
+        args = args.concat(options);
+    }
+
+    return cmd(options, ...args);
+}
+
+export async function readCommitMessage(...options: string[]): Promise<string> {
+    core.debug(`Executing 'git show -s --format='%s' HEAD' with options '${options.join(' ')}'`);
+
+    let args = ['show', '-s', '--format=%s', 'HEAD'];
+    if (options.length > 0) {
+        args = args.concat(options);
+    }
+
+    return cmd(options, ...args);
+}
+
 function getRepoRemoteUrl(token: string, repoUrl: string): string {
     return `https://x-access-token:${token}@${repoUrl}.git`;
 }

--- a/test/write.spec.ts
+++ b/test/write.spec.ts
@@ -247,497 +247,497 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
             repoPayload?: null | RepositoryPayloadSubset;
             gitServerUrl?: string;
         }> = [
-                {
-                    it: 'appends new result to existing data',
-                    config: defaultCfg,
-                    data: {
-                        lastUpdate,
-                        repoUrl,
-                        entries: {
-                            'Test benchmark': [
-                                {
-                                    commit: commit('prev commit id'),
-                                    date: lastUpdate - 1000,
-                                    tool: 'cargo',
-                                    benches: [bench('bench_fib_10', 100)],
-                                },
-                            ],
-                        },
-                    },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 135)],
-                    },
-                    gitServerUrl: serverUrl,
-                },
-                {
-                    it: 'creates new data file',
-                    config: defaultCfg,
-                    data: null,
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 135)],
+            {
+                it: 'appends new result to existing data',
+                config: defaultCfg,
+                data: {
+                    lastUpdate,
+                    repoUrl,
+                    entries: {
+                        'Test benchmark': [
+                            {
+                                commit: commit('prev commit id'),
+                                date: lastUpdate - 1000,
+                                tool: 'cargo',
+                                benches: [bench('bench_fib_10', 100)],
+                            },
+                        ],
                     },
                 },
-                {
-                    it: 'creates new result suite to existing data file',
-                    config: defaultCfg,
-                    data: {
-                        lastUpdate,
-                        repoUrl,
-                        entries: {
-                            'Other benchmark': [
-                                {
-                                    commit: commit('prev commit id'),
-                                    date: lastUpdate - 1000,
-                                    tool: 'cargo',
-                                    benches: [bench('bench_fib_10', 10)],
-                                },
-                            ],
-                        },
-                    },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 135)],
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 135)],
+                },
+                gitServerUrl: serverUrl,
+            },
+            {
+                it: 'creates new data file',
+                config: defaultCfg,
+                data: null,
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 135)],
+                },
+            },
+            {
+                it: 'creates new result suite to existing data file',
+                config: defaultCfg,
+                data: {
+                    lastUpdate,
+                    repoUrl,
+                    entries: {
+                        'Other benchmark': [
+                            {
+                                commit: commit('prev commit id'),
+                                date: lastUpdate - 1000,
+                                tool: 'cargo',
+                                benches: [bench('bench_fib_10', 10)],
+                            },
+                        ],
                     },
                 },
-                {
-                    it: 'appends new result to existing multiple benchmarks data',
-                    config: defaultCfg,
-                    data: {
-                        lastUpdate,
-                        repoUrl,
-                        entries: {
-                            'Test benchmark': [
-                                {
-                                    commit: commit('prev commit id'),
-                                    date: lastUpdate - 1000,
-                                    tool: 'pytest',
-                                    benches: [bench('bench_fib_10', 100)],
-                                },
-                            ],
-                            'Other benchmark': [
-                                {
-                                    commit: commit('prev commit id'),
-                                    date: lastUpdate - 1000,
-                                    tool: 'cargo',
-                                    benches: [bench('bench_fib_10', 10)],
-                                },
-                            ],
-                        },
-                    },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'pytest',
-                        benches: [bench('bench_fib_10', 135)],
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 135)],
+                },
+            },
+            {
+                it: 'appends new result to existing multiple benchmarks data',
+                config: defaultCfg,
+                data: {
+                    lastUpdate,
+                    repoUrl,
+                    entries: {
+                        'Test benchmark': [
+                            {
+                                commit: commit('prev commit id'),
+                                date: lastUpdate - 1000,
+                                tool: 'pytest',
+                                benches: [bench('bench_fib_10', 100)],
+                            },
+                        ],
+                        'Other benchmark': [
+                            {
+                                commit: commit('prev commit id'),
+                                date: lastUpdate - 1000,
+                                tool: 'cargo',
+                                benches: [bench('bench_fib_10', 10)],
+                            },
+                        ],
                     },
                 },
-                {
-                    it: 'raises an alert when exceeding threshold 2.0',
-                    config: defaultCfg,
-                    data: {
-                        lastUpdate,
-                        repoUrl,
-                        entries: {
-                            'Test benchmark': [
-                                {
-                                    commit: commit('prev commit id'),
-                                    date: lastUpdate - 1000,
-                                    tool: 'go',
-                                    benches: [bench('bench_fib_10', 100), bench('bench_fib_20', 10000)],
-                                },
-                            ],
-                        },
-                    },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'go',
-                        benches: [bench('bench_fib_10', 210), bench('bench_fib_20', 25000)], // Exceeds 2.0 threshold
-                    },
-                    error: [
-                        '# :warning: **Performance Alert** :warning:',
-                        '',
-                        "Possible performance regression was detected for benchmark **'Test benchmark'**.",
-                        'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
-                        '',
-                        '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
-                        '|-|-|-|-|',
-                        '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
-                        '| `bench_fib_20` | `25000` ns/iter (`± 20`) | `10000` ns/iter (`± 20`) | `2.50` |',
-                        '',
-                        `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
-                        '',
-                        'CC: @user',
-                    ],
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'pytest',
+                    benches: [bench('bench_fib_10', 135)],
                 },
-                {
-                    it: 'raises an alert with tool whose result value is bigger-is-better',
-                    config: defaultCfg,
-                    data: {
-                        lastUpdate,
-                        repoUrl,
-                        entries: {
-                            'Test benchmark': [
-                                {
-                                    commit: commit('prev commit id'),
-                                    date: lastUpdate - 1000,
-                                    tool: 'benchmarkjs',
-                                    benches: [bench('benchFib10', 100, '+-20', 'ops/sec')],
-                                },
-                            ],
-                        },
+            },
+            {
+                it: 'raises an alert when exceeding threshold 2.0',
+                config: defaultCfg,
+                data: {
+                    lastUpdate,
+                    repoUrl,
+                    entries: {
+                        'Test benchmark': [
+                            {
+                                commit: commit('prev commit id'),
+                                date: lastUpdate - 1000,
+                                tool: 'go',
+                                benches: [bench('bench_fib_10', 100), bench('bench_fib_20', 10000)],
+                            },
+                        ],
                     },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'benchmarkjs',
-                        benches: [bench('benchFib10', 20, '+-20', 'ops/sec')], // ops/sec so bigger is better
-                    },
-                    error: [
-                        '# :warning: **Performance Alert** :warning:',
-                        '',
-                        "Possible performance regression was detected for benchmark **'Test benchmark'**.",
-                        'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
-                        '',
-                        '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
-                        '|-|-|-|-|',
-                        '| `benchFib10` | `20` ops/sec (`+-20`) | `100` ops/sec (`+-20`) | `5` |',
-                        '',
-                        `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
-                        '',
-                        'CC: @user',
-                    ],
                 },
-                {
-                    it: 'raises an alert without benchmark name with default benchmark name',
-                    config: { ...defaultCfg, name: 'Benchmark' },
-                    data: {
-                        lastUpdate,
-                        repoUrl,
-                        entries: {
-                            Benchmark: [
-                                {
-                                    commit: commit('prev commit id'),
-                                    date: lastUpdate - 1000,
-                                    tool: 'cargo',
-                                    benches: [bench('bench_fib_10', 100)],
-                                },
-                            ],
-                        },
-                    },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
-                    },
-                    error: [
-                        '# :warning: **Performance Alert** :warning:',
-                        '',
-                        'Possible performance regression was detected for benchmark.',
-                        'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
-                        '',
-                        '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
-                        '|-|-|-|-|',
-                        '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
-                        '',
-                        `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
-                        '',
-                        'CC: @user',
-                    ],
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'go',
+                    benches: [bench('bench_fib_10', 210), bench('bench_fib_20', 25000)], // Exceeds 2.0 threshold
                 },
-                {
-                    it: 'raises an alert without CC names',
-                    config: { ...defaultCfg, alertCommentCcUsers: [] },
-                    data: {
-                        lastUpdate,
-                        repoUrl,
-                        entries: {
-                            'Test benchmark': [
-                                {
-                                    commit: commit('prev commit id'),
-                                    date: lastUpdate - 1000,
-                                    tool: 'googlecpp',
-                                    benches: [bench('bench_fib_10', 100)],
-                                },
-                            ],
-                        },
+                error: [
+                    '# :warning: **Performance Alert** :warning:',
+                    '',
+                    "Possible performance regression was detected for benchmark **'Test benchmark'**.",
+                    'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
+                    '',
+                    '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
+                    '|-|-|-|-|',
+                    '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
+                    '| `bench_fib_20` | `25000` ns/iter (`± 20`) | `10000` ns/iter (`± 20`) | `2.50` |',
+                    '',
+                    `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
+                    '',
+                    'CC: @user',
+                ],
+            },
+            {
+                it: 'raises an alert with tool whose result value is bigger-is-better',
+                config: defaultCfg,
+                data: {
+                    lastUpdate,
+                    repoUrl,
+                    entries: {
+                        'Test benchmark': [
+                            {
+                                commit: commit('prev commit id'),
+                                date: lastUpdate - 1000,
+                                tool: 'benchmarkjs',
+                                benches: [bench('benchFib10', 100, '+-20', 'ops/sec')],
+                            },
+                        ],
                     },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'googlecpp',
-                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
-                    },
-                    error: [
-                        '# :warning: **Performance Alert** :warning:',
-                        '',
-                        "Possible performance regression was detected for benchmark **'Test benchmark'**.",
-                        'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
-                        '',
-                        '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
-                        '|-|-|-|-|',
-                        '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
-                        '',
-                        `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
-                    ],
                 },
-                {
-                    it: 'sends commit comment on alert with GitHub API',
-                    config: { ...defaultCfg, commentOnAlert: true, githubToken: 'dummy token' },
-                    data: {
-                        lastUpdate,
-                        repoUrl,
-                        entries: {
-                            'Test benchmark': [
-                                {
-                                    commit: commit('prev commit id'),
-                                    date: lastUpdate - 1000,
-                                    tool: 'cargo',
-                                    benches: [bench('bench_fib_10', 100)],
-                                },
-                            ],
-                        },
-                    },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
-                    },
-                    commitComment: 'Comment was generated at https://dummy-comment-url',
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'benchmarkjs',
+                    benches: [bench('benchFib10', 20, '+-20', 'ops/sec')], // ops/sec so bigger is better
                 },
-                {
-                    it: 'does not raise an alert when both comment-on-alert and fail-on-alert are disabled',
-                    config: { ...defaultCfg, commentOnAlert: false, failOnAlert: false },
-                    data: {
-                        lastUpdate,
-                        repoUrl,
-                        entries: {
-                            'Test benchmark': [
-                                {
-                                    commit: commit('prev commit id'),
-                                    date: lastUpdate - 1000,
-                                    tool: 'cargo',
-                                    benches: [bench('bench_fib_10', 100)],
-                                },
-                            ],
-                        },
+                error: [
+                    '# :warning: **Performance Alert** :warning:',
+                    '',
+                    "Possible performance regression was detected for benchmark **'Test benchmark'**.",
+                    'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
+                    '',
+                    '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
+                    '|-|-|-|-|',
+                    '| `benchFib10` | `20` ops/sec (`+-20`) | `100` ops/sec (`+-20`) | `5` |',
+                    '',
+                    `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
+                    '',
+                    'CC: @user',
+                ],
+            },
+            {
+                it: 'raises an alert without benchmark name with default benchmark name',
+                config: { ...defaultCfg, name: 'Benchmark' },
+                data: {
+                    lastUpdate,
+                    repoUrl,
+                    entries: {
+                        Benchmark: [
+                            {
+                                commit: commit('prev commit id'),
+                                date: lastUpdate - 1000,
+                                tool: 'cargo',
+                                benches: [bench('bench_fib_10', 100)],
+                            },
+                        ],
                     },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
-                    },
-                    error: undefined,
-                    commitComment: undefined,
                 },
-                {
-                    it: 'ignores other bench case on detecting alerts',
-                    config: defaultCfg,
-                    data: {
-                        lastUpdate,
-                        repoUrl,
-                        entries: {
-                            'Test benchmark': [
-                                {
-                                    commit: commit('prev commit id'),
-                                    date: lastUpdate - 1000,
-                                    tool: 'cargo',
-                                    benches: [bench('another_bench', 100)],
-                                },
-                            ],
-                        },
-                    },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
-                    },
-                    error: undefined,
-                    commitComment: undefined,
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
                 },
-                {
-                    it: 'throws an error when GitHub token is not set (though this case should not happen in favor of validation)',
-                    config: { ...defaultCfg, commentOnAlert: true },
-                    data: {
-                        lastUpdate,
-                        repoUrl,
-                        entries: {
-                            'Test benchmark': [
-                                {
-                                    commit: commit('prev commit id'),
-                                    date: lastUpdate - 1000,
-                                    tool: 'cargo',
-                                    benches: [bench('bench_fib_10', 100)],
-                                },
-                            ],
-                        },
+                error: [
+                    '# :warning: **Performance Alert** :warning:',
+                    '',
+                    'Possible performance regression was detected for benchmark.',
+                    'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
+                    '',
+                    '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
+                    '|-|-|-|-|',
+                    '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
+                    '',
+                    `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
+                    '',
+                    'CC: @user',
+                ],
+            },
+            {
+                it: 'raises an alert without CC names',
+                config: { ...defaultCfg, alertCommentCcUsers: [] },
+                data: {
+                    lastUpdate,
+                    repoUrl,
+                    entries: {
+                        'Test benchmark': [
+                            {
+                                commit: commit('prev commit id'),
+                                date: lastUpdate - 1000,
+                                tool: 'googlecpp',
+                                benches: [bench('bench_fib_10', 100)],
+                            },
+                        ],
                     },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
-                    },
-                    error: ["'comment-on-alert' input is set but 'github-token' input is not set"],
-                    commitComment: undefined,
                 },
-                {
-                    it: 'truncates data items if it exceeds max-items-in-chart',
-                    config: { ...defaultCfg, maxItemsInChart: 1 },
-                    data: {
-                        lastUpdate,
-                        repoUrl,
-                        entries: {
-                            'Test benchmark': [
-                                {
-                                    commit: commit('prev commit id'),
-                                    date: lastUpdate - 1000,
-                                    tool: 'go',
-                                    benches: [bench('bench_fib_10', 100), bench('bench_fib_20', 10000)],
-                                },
-                            ],
-                        },
-                    },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'go',
-                        benches: [bench('bench_fib_10', 210), bench('bench_fib_20', 25000)], // Exceeds 2.0 threshold
-                    },
-                    // Though first item is truncated due to maxItemsInChart, alert still can be raised since previous data
-                    // is obtained before truncating an array of data items.
-                    error: [
-                        '# :warning: **Performance Alert** :warning:',
-                        '',
-                        "Possible performance regression was detected for benchmark **'Test benchmark'**.",
-                        'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
-                        '',
-                        '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
-                        '|-|-|-|-|',
-                        '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
-                        '| `bench_fib_20` | `25000` ns/iter (`± 20`) | `10000` ns/iter (`± 20`) | `2.50` |',
-                        '',
-                        `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
-                        '',
-                        'CC: @user',
-                    ],
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'googlecpp',
+                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
                 },
-                {
-                    it: 'changes title when threshold is zero which means comment always happens',
-                    config: { ...defaultCfg, alertThreshold: 0, failThreshold: 0 },
-                    data: {
-                        lastUpdate,
-                        repoUrl,
-                        entries: {
-                            'Test benchmark': [
-                                {
-                                    commit: commit('prev commit id'),
-                                    date: lastUpdate - 1000,
-                                    tool: 'benchmarkjs',
-                                    benches: [bench('benchFib10', 100, '+-20', 'ops/sec')],
-                                },
-                            ],
-                        },
+                error: [
+                    '# :warning: **Performance Alert** :warning:',
+                    '',
+                    "Possible performance regression was detected for benchmark **'Test benchmark'**.",
+                    'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
+                    '',
+                    '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
+                    '|-|-|-|-|',
+                    '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
+                    '',
+                    `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
+                ],
+            },
+            {
+                it: 'sends commit comment on alert with GitHub API',
+                config: { ...defaultCfg, commentOnAlert: true, githubToken: 'dummy token' },
+                data: {
+                    lastUpdate,
+                    repoUrl,
+                    entries: {
+                        'Test benchmark': [
+                            {
+                                commit: commit('prev commit id'),
+                                date: lastUpdate - 1000,
+                                tool: 'cargo',
+                                benches: [bench('bench_fib_10', 100)],
+                            },
+                        ],
                     },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'benchmarkjs',
-                        benches: [bench('benchFib10', 100, '+-20', 'ops/sec')],
-                    },
-                    error: [
-                        '# Performance Report',
-                        '',
-                        "Possible performance regression was detected for benchmark **'Test benchmark'**.",
-                        'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `0`.',
-                        '',
-                        '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
-                        '|-|-|-|-|',
-                        '| `benchFib10` | `100` ops/sec (`+-20`) | `100` ops/sec (`+-20`) | `1` |',
-                        '',
-                        `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
-                        '',
-                        'CC: @user',
-                    ],
                 },
-                {
-                    it: 'raises an alert with different failure threshold from alert threshold',
-                    config: { ...defaultCfg, failThreshold: 3 },
-                    data: {
-                        lastUpdate,
-                        repoUrl,
-                        entries: {
-                            'Test benchmark': [
-                                {
-                                    commit: commit('prev commit id'),
-                                    date: lastUpdate - 1000,
-                                    tool: 'go',
-                                    benches: [bench('bench_fib_10', 100)],
-                                },
-                            ],
-                        },
-                    },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'go',
-                        benches: [bench('bench_fib_10', 350)], // Exceeds 3.0 failure threshold
-                    },
-                    error: [
-                        '1 of 1 alerts exceeded the failure threshold `3` specified by fail-threshold input:',
-                        '',
-                        '# :warning: **Performance Alert** :warning:',
-                        '',
-                        "Possible performance regression was detected for benchmark **'Test benchmark'**.",
-                        'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
-                        '',
-                        '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
-                        '|-|-|-|-|',
-                        '| `bench_fib_10` | `350` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `3.50` |',
-                        '',
-                        `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
-                        '',
-                        'CC: @user',
-                    ],
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
                 },
-                {
-                    it: 'does not raise an alert when not exceeding failure threshold',
-                    config: { ...defaultCfg, failThreshold: 3 },
-                    data: {
-                        lastUpdate,
-                        repoUrl,
-                        entries: {
-                            'Test benchmark': [
-                                {
-                                    commit: commit('prev commit id'),
-                                    date: lastUpdate - 1000,
-                                    tool: 'go',
-                                    benches: [bench('bench_fib_10', 100)],
-                                },
-                            ],
-                        },
+                commitComment: 'Comment was generated at https://dummy-comment-url',
+            },
+            {
+                it: 'does not raise an alert when both comment-on-alert and fail-on-alert are disabled',
+                config: { ...defaultCfg, commentOnAlert: false, failOnAlert: false },
+                data: {
+                    lastUpdate,
+                    repoUrl,
+                    entries: {
+                        'Test benchmark': [
+                            {
+                                commit: commit('prev commit id'),
+                                date: lastUpdate - 1000,
+                                tool: 'cargo',
+                                benches: [bench('bench_fib_10', 100)],
+                            },
+                        ],
                     },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'go',
-                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
-                    },
-                    error: undefined,
                 },
-            ];
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
+                },
+                error: undefined,
+                commitComment: undefined,
+            },
+            {
+                it: 'ignores other bench case on detecting alerts',
+                config: defaultCfg,
+                data: {
+                    lastUpdate,
+                    repoUrl,
+                    entries: {
+                        'Test benchmark': [
+                            {
+                                commit: commit('prev commit id'),
+                                date: lastUpdate - 1000,
+                                tool: 'cargo',
+                                benches: [bench('another_bench', 100)],
+                            },
+                        ],
+                    },
+                },
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
+                },
+                error: undefined,
+                commitComment: undefined,
+            },
+            {
+                it: 'throws an error when GitHub token is not set (though this case should not happen in favor of validation)',
+                config: { ...defaultCfg, commentOnAlert: true },
+                data: {
+                    lastUpdate,
+                    repoUrl,
+                    entries: {
+                        'Test benchmark': [
+                            {
+                                commit: commit('prev commit id'),
+                                date: lastUpdate - 1000,
+                                tool: 'cargo',
+                                benches: [bench('bench_fib_10', 100)],
+                            },
+                        ],
+                    },
+                },
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
+                },
+                error: ["'comment-on-alert' input is set but 'github-token' input is not set"],
+                commitComment: undefined,
+            },
+            {
+                it: 'truncates data items if it exceeds max-items-in-chart',
+                config: { ...defaultCfg, maxItemsInChart: 1 },
+                data: {
+                    lastUpdate,
+                    repoUrl,
+                    entries: {
+                        'Test benchmark': [
+                            {
+                                commit: commit('prev commit id'),
+                                date: lastUpdate - 1000,
+                                tool: 'go',
+                                benches: [bench('bench_fib_10', 100), bench('bench_fib_20', 10000)],
+                            },
+                        ],
+                    },
+                },
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'go',
+                    benches: [bench('bench_fib_10', 210), bench('bench_fib_20', 25000)], // Exceeds 2.0 threshold
+                },
+                // Though first item is truncated due to maxItemsInChart, alert still can be raised since previous data
+                // is obtained before truncating an array of data items.
+                error: [
+                    '# :warning: **Performance Alert** :warning:',
+                    '',
+                    "Possible performance regression was detected for benchmark **'Test benchmark'**.",
+                    'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
+                    '',
+                    '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
+                    '|-|-|-|-|',
+                    '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
+                    '| `bench_fib_20` | `25000` ns/iter (`± 20`) | `10000` ns/iter (`± 20`) | `2.50` |',
+                    '',
+                    `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
+                    '',
+                    'CC: @user',
+                ],
+            },
+            {
+                it: 'changes title when threshold is zero which means comment always happens',
+                config: { ...defaultCfg, alertThreshold: 0, failThreshold: 0 },
+                data: {
+                    lastUpdate,
+                    repoUrl,
+                    entries: {
+                        'Test benchmark': [
+                            {
+                                commit: commit('prev commit id'),
+                                date: lastUpdate - 1000,
+                                tool: 'benchmarkjs',
+                                benches: [bench('benchFib10', 100, '+-20', 'ops/sec')],
+                            },
+                        ],
+                    },
+                },
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'benchmarkjs',
+                    benches: [bench('benchFib10', 100, '+-20', 'ops/sec')],
+                },
+                error: [
+                    '# Performance Report',
+                    '',
+                    "Possible performance regression was detected for benchmark **'Test benchmark'**.",
+                    'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `0`.',
+                    '',
+                    '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
+                    '|-|-|-|-|',
+                    '| `benchFib10` | `100` ops/sec (`+-20`) | `100` ops/sec (`+-20`) | `1` |',
+                    '',
+                    `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
+                    '',
+                    'CC: @user',
+                ],
+            },
+            {
+                it: 'raises an alert with different failure threshold from alert threshold',
+                config: { ...defaultCfg, failThreshold: 3 },
+                data: {
+                    lastUpdate,
+                    repoUrl,
+                    entries: {
+                        'Test benchmark': [
+                            {
+                                commit: commit('prev commit id'),
+                                date: lastUpdate - 1000,
+                                tool: 'go',
+                                benches: [bench('bench_fib_10', 100)],
+                            },
+                        ],
+                    },
+                },
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'go',
+                    benches: [bench('bench_fib_10', 350)], // Exceeds 3.0 failure threshold
+                },
+                error: [
+                    '1 of 1 alerts exceeded the failure threshold `3` specified by fail-threshold input:',
+                    '',
+                    '# :warning: **Performance Alert** :warning:',
+                    '',
+                    "Possible performance regression was detected for benchmark **'Test benchmark'**.",
+                    'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
+                    '',
+                    '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
+                    '|-|-|-|-|',
+                    '| `bench_fib_10` | `350` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `3.50` |',
+                    '',
+                    `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
+                    '',
+                    'CC: @user',
+                ],
+            },
+            {
+                it: 'does not raise an alert when not exceeding failure threshold',
+                config: { ...defaultCfg, failThreshold: 3 },
+                data: {
+                    lastUpdate,
+                    repoUrl,
+                    entries: {
+                        'Test benchmark': [
+                            {
+                                commit: commit('prev commit id'),
+                                date: lastUpdate - 1000,
+                                tool: 'go',
+                                benches: [bench('bench_fib_10', 100)],
+                            },
+                        ],
+                    },
+                },
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'go',
+                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
+                },
+                error: undefined,
+            },
+        ];
 
         for (const t of normalCases) {
             it(t.it, async function () {
@@ -961,266 +961,266 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
             error?: string[];
             expectedDataBaseDirectory?: string;
         }> = [
-                {
-                    it: 'appends new data',
-                    config: defaultCfg,
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 135)],
-                    },
-                    gitServerUrl: serverUrl,
-                    gitHistory: gitHistory(),
+            {
+                it: 'appends new data',
+                config: defaultCfg,
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 135)],
                 },
-                {
-                    it: 'creates new data file',
-                    config: { ...defaultCfg, benchmarkDataDirPath: 'new-data-dir' },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 135)],
-                    },
-                    gitServerUrl: serverUrl,
-                    gitHistory: gitHistory({ dir: 'new-data-dir' }),
+                gitServerUrl: serverUrl,
+                gitHistory: gitHistory(),
+            },
+            {
+                it: 'creates new data file',
+                config: { ...defaultCfg, benchmarkDataDirPath: 'new-data-dir' },
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 135)],
                 },
-                {
-                    it: 'appends new data in other repository',
-                    config: {
-                        ...defaultCfg,
-                        ghRepository: 'https://github.com/user/other-repo',
-                        benchmarkDataDirPath: 'data-dir',
-                    },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 135)],
-                    },
-                    gitServerUrl: serverUrl,
-                    gitHistory: [
-                        ['clone', ['dummy token', 'https://github.com/user/other-repo', './benchmark-data-repository']],
+                gitServerUrl: serverUrl,
+                gitHistory: gitHistory({ dir: 'new-data-dir' }),
+            },
+            {
+                it: 'appends new data in other repository',
+                config: {
+                    ...defaultCfg,
+                    ghRepository: 'https://github.com/user/other-repo',
+                    benchmarkDataDirPath: 'data-dir',
+                },
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 135)],
+                },
+                gitServerUrl: serverUrl,
+                gitHistory: [
+                    ['clone', ['dummy token', 'https://github.com/user/other-repo', './benchmark-data-repository']],
+                    [
+                        'checkout',
                         [
-                            'checkout',
-                            [
-                                'gh-pages',
-                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                            ],
-                        ],
-                        [
-                            'cmd',
-                            [
-                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                                'add',
-                                path.join('data-dir', 'data.js'),
-                            ],
-                        ],
-                        [
-                            'cmd',
-                            [
-                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                                'add',
-                                path.join('data-dir', 'index.html'),
-                            ],
-                        ],
-                        [
-                            'cmd',
-                            [
-                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                                'commit',
-                                '-m',
-                                'add Test benchmark (cargo) benchmark result for current commit id',
-                            ],
-                        ],
-                        [
-                            'push',
-                            [
-                                'dummy token',
-                                'https://github.com/user/other-repo',
-                                'gh-pages',
-                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                            ],
+                            'gh-pages',
+                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
                         ],
                     ],
-                    expectedDataBaseDirectory: 'benchmark-data-repository',
-                },
-                {
-                    it: 'creates new data file in other repository',
-                    config: {
-                        ...defaultCfg,
-                        ghRepository: 'https://github.com/user/other-repo',
-                    },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 135)],
-                    },
-                    gitServerUrl: serverUrl,
-                    gitHistory: [
-                        ['clone', ['dummy token', 'https://github.com/user/other-repo', './benchmark-data-repository']],
+                    [
+                        'cmd',
                         [
-                            'checkout',
-                            [
-                                'gh-pages',
-                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                            ],
-                        ],
-                        [
-                            'cmd',
-                            [
-                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                                'add',
-                                path.join('data-dir', 'data.js'),
-                            ],
-                        ],
-                        [
-                            'cmd',
-                            [
-                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                                'add',
-                                path.join('data-dir', 'index.html'),
-                            ],
-                        ],
-                        [
-                            'cmd',
-                            [
-                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                                'commit',
-                                '-m',
-                                'add Test benchmark (cargo) benchmark result for current commit id',
-                            ],
-                        ],
-                        [
-                            'push',
-                            [
-                                'dummy token',
-                                'https://github.com/user/other-repo',
-                                'gh-pages',
-                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                            ],
+                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                            'add',
+                            path.join('data-dir', 'data.js'),
                         ],
                     ],
-                    expectedDataBaseDirectory: 'benchmark-data-repository',
-                },
-                {
-                    it: 'creates new suite in data',
-                    config: defaultCfg,
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('other_bench_foo', 100)],
-                    },
-                    gitServerUrl: serverUrl,
-                    gitHistory: gitHistory(),
-                },
-                {
-                    it: 'does not create index.html if it already exists',
-                    config: { ...defaultCfg, benchmarkDataDirPath: 'with-index-html' },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 100)],
-                    },
-                    gitServerUrl: serverUrl,
-                    gitHistory: gitHistory({ dir: 'with-index-html', addIndexHtml: false }),
-                },
-                {
-                    it: 'does not push to remote when auto-push is off',
-                    config: { ...defaultCfg, autoPush: false },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 135)],
-                    },
-                    gitServerUrl: serverUrl,
-                    gitHistory: gitHistory({ autoPush: false }),
-                },
-                {
-                    it: 'does not push to remote when auto-push is off without token',
-                    config: { ...defaultCfg, autoPush: false, githubToken: undefined },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 135)],
-                    },
-                    gitServerUrl: serverUrl,
-                    gitHistory: gitHistory({ autoPush: false, token: undefined }),
-                },
-                {
-                    it: 'does not fetch remote when github-token is not set for private repo',
-                    config: { ...defaultCfg, autoPush: false, githubToken: undefined },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 135)],
-                    },
-                    gitServerUrl: serverUrl,
-                    gitHistory: gitHistory({ autoPush: false, token: undefined, fetch: false }),
-                    privateRepo: true,
-                },
-                {
-                    it: 'does not fetch remote when skip-fetch-gh-pages is enabled',
-                    config: { ...defaultCfg, skipFetchGhPages: true },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 135)],
-                    },
-                    gitServerUrl: serverUrl,
-                    gitHistory: gitHistory({ fetch: false, skipFetch: true }),
-                },
-                {
-                    it: 'fails when exceeding the threshold',
-                    config: defaultCfg,
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
-                    },
-                    gitServerUrl: serverUrl,
-                    gitHistory: gitHistory(),
-                    error: [
-                        '# :warning: **Performance Alert** :warning:',
-                        '',
-                        "Possible performance regression was detected for benchmark **'Test benchmark'**.",
-                        'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
-                        '',
-                        '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
-                        '|-|-|-|-|',
-                        '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
-                        '',
-                        `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
+                    [
+                        'cmd',
+                        [
+                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                            'add',
+                            path.join('data-dir', 'index.html'),
+                        ],
                     ],
+                    [
+                        'cmd',
+                        [
+                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                            'commit',
+                            '-m',
+                            'add Test benchmark (cargo) benchmark result for current commit id',
+                        ],
+                    ],
+                    [
+                        'push',
+                        [
+                            'dummy token',
+                            'https://github.com/user/other-repo',
+                            'gh-pages',
+                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                        ],
+                    ],
+                ],
+                expectedDataBaseDirectory: 'benchmark-data-repository',
+            },
+            {
+                it: 'creates new data file in other repository',
+                config: {
+                    ...defaultCfg,
+                    ghRepository: 'https://github.com/user/other-repo',
                 },
-                {
-                    it: 'sends commit message but does not raise an error when exceeding alert threshold but not exceeding failure threshold',
-                    config: {
-                        ...defaultCfg,
-                        commentOnAlert: true,
-                        githubToken: 'dummy token',
-                        alertThreshold: 2,
-                        failThreshold: 3,
-                    },
-                    added: {
-                        commit: commit('current commit id'),
-                        date: lastUpdate,
-                        tool: 'cargo',
-                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold but not exceed 3.0 threshold
-                    },
-                    gitServerUrl: serverUrl,
-                    gitHistory: gitHistory(),
-                    error: undefined,
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 135)],
                 },
-            ];
+                gitServerUrl: serverUrl,
+                gitHistory: [
+                    ['clone', ['dummy token', 'https://github.com/user/other-repo', './benchmark-data-repository']],
+                    [
+                        'checkout',
+                        [
+                            'gh-pages',
+                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                        ],
+                    ],
+                    [
+                        'cmd',
+                        [
+                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                            'add',
+                            path.join('data-dir', 'data.js'),
+                        ],
+                    ],
+                    [
+                        'cmd',
+                        [
+                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                            'add',
+                            path.join('data-dir', 'index.html'),
+                        ],
+                    ],
+                    [
+                        'cmd',
+                        [
+                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                            'commit',
+                            '-m',
+                            'add Test benchmark (cargo) benchmark result for current commit id',
+                        ],
+                    ],
+                    [
+                        'push',
+                        [
+                            'dummy token',
+                            'https://github.com/user/other-repo',
+                            'gh-pages',
+                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                        ],
+                    ],
+                ],
+                expectedDataBaseDirectory: 'benchmark-data-repository',
+            },
+            {
+                it: 'creates new suite in data',
+                config: defaultCfg,
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('other_bench_foo', 100)],
+                },
+                gitServerUrl: serverUrl,
+                gitHistory: gitHistory(),
+            },
+            {
+                it: 'does not create index.html if it already exists',
+                config: { ...defaultCfg, benchmarkDataDirPath: 'with-index-html' },
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 100)],
+                },
+                gitServerUrl: serverUrl,
+                gitHistory: gitHistory({ dir: 'with-index-html', addIndexHtml: false }),
+            },
+            {
+                it: 'does not push to remote when auto-push is off',
+                config: { ...defaultCfg, autoPush: false },
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 135)],
+                },
+                gitServerUrl: serverUrl,
+                gitHistory: gitHistory({ autoPush: false }),
+            },
+            {
+                it: 'does not push to remote when auto-push is off without token',
+                config: { ...defaultCfg, autoPush: false, githubToken: undefined },
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 135)],
+                },
+                gitServerUrl: serverUrl,
+                gitHistory: gitHistory({ autoPush: false, token: undefined }),
+            },
+            {
+                it: 'does not fetch remote when github-token is not set for private repo',
+                config: { ...defaultCfg, autoPush: false, githubToken: undefined },
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 135)],
+                },
+                gitServerUrl: serverUrl,
+                gitHistory: gitHistory({ autoPush: false, token: undefined, fetch: false }),
+                privateRepo: true,
+            },
+            {
+                it: 'does not fetch remote when skip-fetch-gh-pages is enabled',
+                config: { ...defaultCfg, skipFetchGhPages: true },
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 135)],
+                },
+                gitServerUrl: serverUrl,
+                gitHistory: gitHistory({ fetch: false, skipFetch: true }),
+            },
+            {
+                it: 'fails when exceeding the threshold',
+                config: defaultCfg,
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
+                },
+                gitServerUrl: serverUrl,
+                gitHistory: gitHistory(),
+                error: [
+                    '# :warning: **Performance Alert** :warning:',
+                    '',
+                    "Possible performance regression was detected for benchmark **'Test benchmark'**.",
+                    'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
+                    '',
+                    '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
+                    '|-|-|-|-|',
+                    '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
+                    '',
+                    `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
+                ],
+            },
+            {
+                it: 'sends commit message but does not raise an error when exceeding alert threshold but not exceeding failure threshold',
+                config: {
+                    ...defaultCfg,
+                    commentOnAlert: true,
+                    githubToken: 'dummy token',
+                    alertThreshold: 2,
+                    failThreshold: 3,
+                },
+                added: {
+                    commit: commit('current commit id'),
+                    date: lastUpdate,
+                    tool: 'cargo',
+                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold but not exceed 3.0 threshold
+                },
+                gitServerUrl: serverUrl,
+                gitHistory: gitHistory(),
+                error: undefined,
+            },
+        ];
         for (const t of normalCases) {
             // FIXME: can't use `it.each` currently as tests running in parallel interfere with each other
             it(t.it, async function () {
@@ -1313,30 +1313,30 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
             pushErrorMessage: string;
             pushErrorCount: number;
         }> = [
-                ...[1, 2].map((retries) => ({
-                    it: `updates data successfully after ${retries} retries`,
-                    pushErrorMessage: '... [remote rejected] ...',
-                    pushErrorCount: retries,
-                })),
-                {
-                    it: `gives up updating data after ${maxRetries} retries with an error`,
-                    pushErrorMessage: '... [remote rejected] ...',
-                    pushErrorCount: maxRetries,
-                    error: /Auto-push failed 3 times since the remote branch gh-pages rejected pushing all the time/,
-                },
-                {
-                    it: `gives up updating data after ${maxRetries} retries with an error containing "[rejected]" in message`,
-                    pushErrorMessage: '... [rejected] ...',
-                    pushErrorCount: maxRetries,
-                    error: /Auto-push failed 3 times since the remote branch gh-pages rejected pushing all the time/,
-                },
-                {
-                    it: 'handles an unexpected error without retry',
-                    pushErrorMessage: 'Some fatal error',
-                    pushErrorCount: 1,
-                    error: /Some fatal error/,
-                },
-            ];
+            ...[1, 2].map((retries) => ({
+                it: `updates data successfully after ${retries} retries`,
+                pushErrorMessage: '... [remote rejected] ...',
+                pushErrorCount: retries,
+            })),
+            {
+                it: `gives up updating data after ${maxRetries} retries with an error`,
+                pushErrorMessage: '... [remote rejected] ...',
+                pushErrorCount: maxRetries,
+                error: /Auto-push failed 3 times since the remote branch gh-pages rejected pushing all the time/,
+            },
+            {
+                it: `gives up updating data after ${maxRetries} retries with an error containing "[rejected]" in message`,
+                pushErrorMessage: '... [rejected] ...',
+                pushErrorCount: maxRetries,
+                error: /Auto-push failed 3 times since the remote branch gh-pages rejected pushing all the time/,
+            },
+            {
+                it: 'handles an unexpected error without retry',
+                pushErrorMessage: 'Some fatal error',
+                pushErrorCount: 1,
+                error: /Some fatal error/,
+            },
+        ];
 
         for (const t of retryCases) {
             it(t.it, async function () {

--- a/test/write.spec.ts
+++ b/test/write.spec.ts
@@ -216,6 +216,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
             failOnAlert: true,
             alertCommentCcUsers: ['@user'],
             externalDataJsonPath: dataJson,
+            readCommitIdFromGit: false,
             maxItemsInChart: null,
             failThreshold: 2.0,
         };
@@ -246,497 +247,497 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
             repoPayload?: null | RepositoryPayloadSubset;
             gitServerUrl?: string;
         }> = [
-            {
-                it: 'appends new result to existing data',
-                config: defaultCfg,
-                data: {
-                    lastUpdate,
-                    repoUrl,
-                    entries: {
-                        'Test benchmark': [
-                            {
-                                commit: commit('prev commit id'),
-                                date: lastUpdate - 1000,
-                                tool: 'cargo',
-                                benches: [bench('bench_fib_10', 100)],
-                            },
-                        ],
+                {
+                    it: 'appends new result to existing data',
+                    config: defaultCfg,
+                    data: {
+                        lastUpdate,
+                        repoUrl,
+                        entries: {
+                            'Test benchmark': [
+                                {
+                                    commit: commit('prev commit id'),
+                                    date: lastUpdate - 1000,
+                                    tool: 'cargo',
+                                    benches: [bench('bench_fib_10', 100)],
+                                },
+                            ],
+                        },
+                    },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 135)],
+                    },
+                    gitServerUrl: serverUrl,
+                },
+                {
+                    it: 'creates new data file',
+                    config: defaultCfg,
+                    data: null,
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 135)],
                     },
                 },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 135)],
-                },
-                gitServerUrl: serverUrl,
-            },
-            {
-                it: 'creates new data file',
-                config: defaultCfg,
-                data: null,
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 135)],
-                },
-            },
-            {
-                it: 'creates new result suite to existing data file',
-                config: defaultCfg,
-                data: {
-                    lastUpdate,
-                    repoUrl,
-                    entries: {
-                        'Other benchmark': [
-                            {
-                                commit: commit('prev commit id'),
-                                date: lastUpdate - 1000,
-                                tool: 'cargo',
-                                benches: [bench('bench_fib_10', 10)],
-                            },
-                        ],
+                {
+                    it: 'creates new result suite to existing data file',
+                    config: defaultCfg,
+                    data: {
+                        lastUpdate,
+                        repoUrl,
+                        entries: {
+                            'Other benchmark': [
+                                {
+                                    commit: commit('prev commit id'),
+                                    date: lastUpdate - 1000,
+                                    tool: 'cargo',
+                                    benches: [bench('bench_fib_10', 10)],
+                                },
+                            ],
+                        },
+                    },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 135)],
                     },
                 },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 135)],
-                },
-            },
-            {
-                it: 'appends new result to existing multiple benchmarks data',
-                config: defaultCfg,
-                data: {
-                    lastUpdate,
-                    repoUrl,
-                    entries: {
-                        'Test benchmark': [
-                            {
-                                commit: commit('prev commit id'),
-                                date: lastUpdate - 1000,
-                                tool: 'pytest',
-                                benches: [bench('bench_fib_10', 100)],
-                            },
-                        ],
-                        'Other benchmark': [
-                            {
-                                commit: commit('prev commit id'),
-                                date: lastUpdate - 1000,
-                                tool: 'cargo',
-                                benches: [bench('bench_fib_10', 10)],
-                            },
-                        ],
+                {
+                    it: 'appends new result to existing multiple benchmarks data',
+                    config: defaultCfg,
+                    data: {
+                        lastUpdate,
+                        repoUrl,
+                        entries: {
+                            'Test benchmark': [
+                                {
+                                    commit: commit('prev commit id'),
+                                    date: lastUpdate - 1000,
+                                    tool: 'pytest',
+                                    benches: [bench('bench_fib_10', 100)],
+                                },
+                            ],
+                            'Other benchmark': [
+                                {
+                                    commit: commit('prev commit id'),
+                                    date: lastUpdate - 1000,
+                                    tool: 'cargo',
+                                    benches: [bench('bench_fib_10', 10)],
+                                },
+                            ],
+                        },
+                    },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'pytest',
+                        benches: [bench('bench_fib_10', 135)],
                     },
                 },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'pytest',
-                    benches: [bench('bench_fib_10', 135)],
-                },
-            },
-            {
-                it: 'raises an alert when exceeding threshold 2.0',
-                config: defaultCfg,
-                data: {
-                    lastUpdate,
-                    repoUrl,
-                    entries: {
-                        'Test benchmark': [
-                            {
-                                commit: commit('prev commit id'),
-                                date: lastUpdate - 1000,
-                                tool: 'go',
-                                benches: [bench('bench_fib_10', 100), bench('bench_fib_20', 10000)],
-                            },
-                        ],
+                {
+                    it: 'raises an alert when exceeding threshold 2.0',
+                    config: defaultCfg,
+                    data: {
+                        lastUpdate,
+                        repoUrl,
+                        entries: {
+                            'Test benchmark': [
+                                {
+                                    commit: commit('prev commit id'),
+                                    date: lastUpdate - 1000,
+                                    tool: 'go',
+                                    benches: [bench('bench_fib_10', 100), bench('bench_fib_20', 10000)],
+                                },
+                            ],
+                        },
                     },
-                },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'go',
-                    benches: [bench('bench_fib_10', 210), bench('bench_fib_20', 25000)], // Exceeds 2.0 threshold
-                },
-                error: [
-                    '# :warning: **Performance Alert** :warning:',
-                    '',
-                    "Possible performance regression was detected for benchmark **'Test benchmark'**.",
-                    'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
-                    '',
-                    '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
-                    '|-|-|-|-|',
-                    '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
-                    '| `bench_fib_20` | `25000` ns/iter (`± 20`) | `10000` ns/iter (`± 20`) | `2.50` |',
-                    '',
-                    `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
-                    '',
-                    'CC: @user',
-                ],
-            },
-            {
-                it: 'raises an alert with tool whose result value is bigger-is-better',
-                config: defaultCfg,
-                data: {
-                    lastUpdate,
-                    repoUrl,
-                    entries: {
-                        'Test benchmark': [
-                            {
-                                commit: commit('prev commit id'),
-                                date: lastUpdate - 1000,
-                                tool: 'benchmarkjs',
-                                benches: [bench('benchFib10', 100, '+-20', 'ops/sec')],
-                            },
-                        ],
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'go',
+                        benches: [bench('bench_fib_10', 210), bench('bench_fib_20', 25000)], // Exceeds 2.0 threshold
                     },
+                    error: [
+                        '# :warning: **Performance Alert** :warning:',
+                        '',
+                        "Possible performance regression was detected for benchmark **'Test benchmark'**.",
+                        'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
+                        '',
+                        '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
+                        '|-|-|-|-|',
+                        '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
+                        '| `bench_fib_20` | `25000` ns/iter (`± 20`) | `10000` ns/iter (`± 20`) | `2.50` |',
+                        '',
+                        `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
+                        '',
+                        'CC: @user',
+                    ],
                 },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'benchmarkjs',
-                    benches: [bench('benchFib10', 20, '+-20', 'ops/sec')], // ops/sec so bigger is better
-                },
-                error: [
-                    '# :warning: **Performance Alert** :warning:',
-                    '',
-                    "Possible performance regression was detected for benchmark **'Test benchmark'**.",
-                    'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
-                    '',
-                    '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
-                    '|-|-|-|-|',
-                    '| `benchFib10` | `20` ops/sec (`+-20`) | `100` ops/sec (`+-20`) | `5` |',
-                    '',
-                    `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
-                    '',
-                    'CC: @user',
-                ],
-            },
-            {
-                it: 'raises an alert without benchmark name with default benchmark name',
-                config: { ...defaultCfg, name: 'Benchmark' },
-                data: {
-                    lastUpdate,
-                    repoUrl,
-                    entries: {
-                        Benchmark: [
-                            {
-                                commit: commit('prev commit id'),
-                                date: lastUpdate - 1000,
-                                tool: 'cargo',
-                                benches: [bench('bench_fib_10', 100)],
-                            },
-                        ],
+                {
+                    it: 'raises an alert with tool whose result value is bigger-is-better',
+                    config: defaultCfg,
+                    data: {
+                        lastUpdate,
+                        repoUrl,
+                        entries: {
+                            'Test benchmark': [
+                                {
+                                    commit: commit('prev commit id'),
+                                    date: lastUpdate - 1000,
+                                    tool: 'benchmarkjs',
+                                    benches: [bench('benchFib10', 100, '+-20', 'ops/sec')],
+                                },
+                            ],
+                        },
                     },
-                },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
-                },
-                error: [
-                    '# :warning: **Performance Alert** :warning:',
-                    '',
-                    'Possible performance regression was detected for benchmark.',
-                    'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
-                    '',
-                    '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
-                    '|-|-|-|-|',
-                    '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
-                    '',
-                    `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
-                    '',
-                    'CC: @user',
-                ],
-            },
-            {
-                it: 'raises an alert without CC names',
-                config: { ...defaultCfg, alertCommentCcUsers: [] },
-                data: {
-                    lastUpdate,
-                    repoUrl,
-                    entries: {
-                        'Test benchmark': [
-                            {
-                                commit: commit('prev commit id'),
-                                date: lastUpdate - 1000,
-                                tool: 'googlecpp',
-                                benches: [bench('bench_fib_10', 100)],
-                            },
-                        ],
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'benchmarkjs',
+                        benches: [bench('benchFib10', 20, '+-20', 'ops/sec')], // ops/sec so bigger is better
                     },
+                    error: [
+                        '# :warning: **Performance Alert** :warning:',
+                        '',
+                        "Possible performance regression was detected for benchmark **'Test benchmark'**.",
+                        'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
+                        '',
+                        '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
+                        '|-|-|-|-|',
+                        '| `benchFib10` | `20` ops/sec (`+-20`) | `100` ops/sec (`+-20`) | `5` |',
+                        '',
+                        `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
+                        '',
+                        'CC: @user',
+                    ],
                 },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'googlecpp',
-                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
-                },
-                error: [
-                    '# :warning: **Performance Alert** :warning:',
-                    '',
-                    "Possible performance regression was detected for benchmark **'Test benchmark'**.",
-                    'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
-                    '',
-                    '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
-                    '|-|-|-|-|',
-                    '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
-                    '',
-                    `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
-                ],
-            },
-            {
-                it: 'sends commit comment on alert with GitHub API',
-                config: { ...defaultCfg, commentOnAlert: true, githubToken: 'dummy token' },
-                data: {
-                    lastUpdate,
-                    repoUrl,
-                    entries: {
-                        'Test benchmark': [
-                            {
-                                commit: commit('prev commit id'),
-                                date: lastUpdate - 1000,
-                                tool: 'cargo',
-                                benches: [bench('bench_fib_10', 100)],
-                            },
-                        ],
+                {
+                    it: 'raises an alert without benchmark name with default benchmark name',
+                    config: { ...defaultCfg, name: 'Benchmark' },
+                    data: {
+                        lastUpdate,
+                        repoUrl,
+                        entries: {
+                            Benchmark: [
+                                {
+                                    commit: commit('prev commit id'),
+                                    date: lastUpdate - 1000,
+                                    tool: 'cargo',
+                                    benches: [bench('bench_fib_10', 100)],
+                                },
+                            ],
+                        },
                     },
-                },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
-                },
-                commitComment: 'Comment was generated at https://dummy-comment-url',
-            },
-            {
-                it: 'does not raise an alert when both comment-on-alert and fail-on-alert are disabled',
-                config: { ...defaultCfg, commentOnAlert: false, failOnAlert: false },
-                data: {
-                    lastUpdate,
-                    repoUrl,
-                    entries: {
-                        'Test benchmark': [
-                            {
-                                commit: commit('prev commit id'),
-                                date: lastUpdate - 1000,
-                                tool: 'cargo',
-                                benches: [bench('bench_fib_10', 100)],
-                            },
-                        ],
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
                     },
+                    error: [
+                        '# :warning: **Performance Alert** :warning:',
+                        '',
+                        'Possible performance regression was detected for benchmark.',
+                        'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
+                        '',
+                        '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
+                        '|-|-|-|-|',
+                        '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
+                        '',
+                        `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
+                        '',
+                        'CC: @user',
+                    ],
                 },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
-                },
-                error: undefined,
-                commitComment: undefined,
-            },
-            {
-                it: 'ignores other bench case on detecting alerts',
-                config: defaultCfg,
-                data: {
-                    lastUpdate,
-                    repoUrl,
-                    entries: {
-                        'Test benchmark': [
-                            {
-                                commit: commit('prev commit id'),
-                                date: lastUpdate - 1000,
-                                tool: 'cargo',
-                                benches: [bench('another_bench', 100)],
-                            },
-                        ],
+                {
+                    it: 'raises an alert without CC names',
+                    config: { ...defaultCfg, alertCommentCcUsers: [] },
+                    data: {
+                        lastUpdate,
+                        repoUrl,
+                        entries: {
+                            'Test benchmark': [
+                                {
+                                    commit: commit('prev commit id'),
+                                    date: lastUpdate - 1000,
+                                    tool: 'googlecpp',
+                                    benches: [bench('bench_fib_10', 100)],
+                                },
+                            ],
+                        },
                     },
-                },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
-                },
-                error: undefined,
-                commitComment: undefined,
-            },
-            {
-                it: 'throws an error when GitHub token is not set (though this case should not happen in favor of validation)',
-                config: { ...defaultCfg, commentOnAlert: true },
-                data: {
-                    lastUpdate,
-                    repoUrl,
-                    entries: {
-                        'Test benchmark': [
-                            {
-                                commit: commit('prev commit id'),
-                                date: lastUpdate - 1000,
-                                tool: 'cargo',
-                                benches: [bench('bench_fib_10', 100)],
-                            },
-                        ],
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'googlecpp',
+                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
                     },
+                    error: [
+                        '# :warning: **Performance Alert** :warning:',
+                        '',
+                        "Possible performance regression was detected for benchmark **'Test benchmark'**.",
+                        'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
+                        '',
+                        '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
+                        '|-|-|-|-|',
+                        '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
+                        '',
+                        `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
+                    ],
                 },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
-                },
-                error: ["'comment-on-alert' input is set but 'github-token' input is not set"],
-                commitComment: undefined,
-            },
-            {
-                it: 'truncates data items if it exceeds max-items-in-chart',
-                config: { ...defaultCfg, maxItemsInChart: 1 },
-                data: {
-                    lastUpdate,
-                    repoUrl,
-                    entries: {
-                        'Test benchmark': [
-                            {
-                                commit: commit('prev commit id'),
-                                date: lastUpdate - 1000,
-                                tool: 'go',
-                                benches: [bench('bench_fib_10', 100), bench('bench_fib_20', 10000)],
-                            },
-                        ],
+                {
+                    it: 'sends commit comment on alert with GitHub API',
+                    config: { ...defaultCfg, commentOnAlert: true, githubToken: 'dummy token' },
+                    data: {
+                        lastUpdate,
+                        repoUrl,
+                        entries: {
+                            'Test benchmark': [
+                                {
+                                    commit: commit('prev commit id'),
+                                    date: lastUpdate - 1000,
+                                    tool: 'cargo',
+                                    benches: [bench('bench_fib_10', 100)],
+                                },
+                            ],
+                        },
                     },
-                },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'go',
-                    benches: [bench('bench_fib_10', 210), bench('bench_fib_20', 25000)], // Exceeds 2.0 threshold
-                },
-                // Though first item is truncated due to maxItemsInChart, alert still can be raised since previous data
-                // is obtained before truncating an array of data items.
-                error: [
-                    '# :warning: **Performance Alert** :warning:',
-                    '',
-                    "Possible performance regression was detected for benchmark **'Test benchmark'**.",
-                    'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
-                    '',
-                    '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
-                    '|-|-|-|-|',
-                    '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
-                    '| `bench_fib_20` | `25000` ns/iter (`± 20`) | `10000` ns/iter (`± 20`) | `2.50` |',
-                    '',
-                    `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
-                    '',
-                    'CC: @user',
-                ],
-            },
-            {
-                it: 'changes title when threshold is zero which means comment always happens',
-                config: { ...defaultCfg, alertThreshold: 0, failThreshold: 0 },
-                data: {
-                    lastUpdate,
-                    repoUrl,
-                    entries: {
-                        'Test benchmark': [
-                            {
-                                commit: commit('prev commit id'),
-                                date: lastUpdate - 1000,
-                                tool: 'benchmarkjs',
-                                benches: [bench('benchFib10', 100, '+-20', 'ops/sec')],
-                            },
-                        ],
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
                     },
+                    commitComment: 'Comment was generated at https://dummy-comment-url',
                 },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'benchmarkjs',
-                    benches: [bench('benchFib10', 100, '+-20', 'ops/sec')],
-                },
-                error: [
-                    '# Performance Report',
-                    '',
-                    "Possible performance regression was detected for benchmark **'Test benchmark'**.",
-                    'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `0`.',
-                    '',
-                    '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
-                    '|-|-|-|-|',
-                    '| `benchFib10` | `100` ops/sec (`+-20`) | `100` ops/sec (`+-20`) | `1` |',
-                    '',
-                    `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
-                    '',
-                    'CC: @user',
-                ],
-            },
-            {
-                it: 'raises an alert with different failure threshold from alert threshold',
-                config: { ...defaultCfg, failThreshold: 3 },
-                data: {
-                    lastUpdate,
-                    repoUrl,
-                    entries: {
-                        'Test benchmark': [
-                            {
-                                commit: commit('prev commit id'),
-                                date: lastUpdate - 1000,
-                                tool: 'go',
-                                benches: [bench('bench_fib_10', 100)],
-                            },
-                        ],
+                {
+                    it: 'does not raise an alert when both comment-on-alert and fail-on-alert are disabled',
+                    config: { ...defaultCfg, commentOnAlert: false, failOnAlert: false },
+                    data: {
+                        lastUpdate,
+                        repoUrl,
+                        entries: {
+                            'Test benchmark': [
+                                {
+                                    commit: commit('prev commit id'),
+                                    date: lastUpdate - 1000,
+                                    tool: 'cargo',
+                                    benches: [bench('bench_fib_10', 100)],
+                                },
+                            ],
+                        },
                     },
-                },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'go',
-                    benches: [bench('bench_fib_10', 350)], // Exceeds 3.0 failure threshold
-                },
-                error: [
-                    '1 of 1 alerts exceeded the failure threshold `3` specified by fail-threshold input:',
-                    '',
-                    '# :warning: **Performance Alert** :warning:',
-                    '',
-                    "Possible performance regression was detected for benchmark **'Test benchmark'**.",
-                    'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
-                    '',
-                    '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
-                    '|-|-|-|-|',
-                    '| `bench_fib_10` | `350` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `3.50` |',
-                    '',
-                    `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
-                    '',
-                    'CC: @user',
-                ],
-            },
-            {
-                it: 'does not raise an alert when not exceeding failure threshold',
-                config: { ...defaultCfg, failThreshold: 3 },
-                data: {
-                    lastUpdate,
-                    repoUrl,
-                    entries: {
-                        'Test benchmark': [
-                            {
-                                commit: commit('prev commit id'),
-                                date: lastUpdate - 1000,
-                                tool: 'go',
-                                benches: [bench('bench_fib_10', 100)],
-                            },
-                        ],
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
                     },
+                    error: undefined,
+                    commitComment: undefined,
                 },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'go',
-                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
+                {
+                    it: 'ignores other bench case on detecting alerts',
+                    config: defaultCfg,
+                    data: {
+                        lastUpdate,
+                        repoUrl,
+                        entries: {
+                            'Test benchmark': [
+                                {
+                                    commit: commit('prev commit id'),
+                                    date: lastUpdate - 1000,
+                                    tool: 'cargo',
+                                    benches: [bench('another_bench', 100)],
+                                },
+                            ],
+                        },
+                    },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
+                    },
+                    error: undefined,
+                    commitComment: undefined,
                 },
-                error: undefined,
-            },
-        ];
+                {
+                    it: 'throws an error when GitHub token is not set (though this case should not happen in favor of validation)',
+                    config: { ...defaultCfg, commentOnAlert: true },
+                    data: {
+                        lastUpdate,
+                        repoUrl,
+                        entries: {
+                            'Test benchmark': [
+                                {
+                                    commit: commit('prev commit id'),
+                                    date: lastUpdate - 1000,
+                                    tool: 'cargo',
+                                    benches: [bench('bench_fib_10', 100)],
+                                },
+                            ],
+                        },
+                    },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
+                    },
+                    error: ["'comment-on-alert' input is set but 'github-token' input is not set"],
+                    commitComment: undefined,
+                },
+                {
+                    it: 'truncates data items if it exceeds max-items-in-chart',
+                    config: { ...defaultCfg, maxItemsInChart: 1 },
+                    data: {
+                        lastUpdate,
+                        repoUrl,
+                        entries: {
+                            'Test benchmark': [
+                                {
+                                    commit: commit('prev commit id'),
+                                    date: lastUpdate - 1000,
+                                    tool: 'go',
+                                    benches: [bench('bench_fib_10', 100), bench('bench_fib_20', 10000)],
+                                },
+                            ],
+                        },
+                    },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'go',
+                        benches: [bench('bench_fib_10', 210), bench('bench_fib_20', 25000)], // Exceeds 2.0 threshold
+                    },
+                    // Though first item is truncated due to maxItemsInChart, alert still can be raised since previous data
+                    // is obtained before truncating an array of data items.
+                    error: [
+                        '# :warning: **Performance Alert** :warning:',
+                        '',
+                        "Possible performance regression was detected for benchmark **'Test benchmark'**.",
+                        'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
+                        '',
+                        '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
+                        '|-|-|-|-|',
+                        '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
+                        '| `bench_fib_20` | `25000` ns/iter (`± 20`) | `10000` ns/iter (`± 20`) | `2.50` |',
+                        '',
+                        `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
+                        '',
+                        'CC: @user',
+                    ],
+                },
+                {
+                    it: 'changes title when threshold is zero which means comment always happens',
+                    config: { ...defaultCfg, alertThreshold: 0, failThreshold: 0 },
+                    data: {
+                        lastUpdate,
+                        repoUrl,
+                        entries: {
+                            'Test benchmark': [
+                                {
+                                    commit: commit('prev commit id'),
+                                    date: lastUpdate - 1000,
+                                    tool: 'benchmarkjs',
+                                    benches: [bench('benchFib10', 100, '+-20', 'ops/sec')],
+                                },
+                            ],
+                        },
+                    },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'benchmarkjs',
+                        benches: [bench('benchFib10', 100, '+-20', 'ops/sec')],
+                    },
+                    error: [
+                        '# Performance Report',
+                        '',
+                        "Possible performance regression was detected for benchmark **'Test benchmark'**.",
+                        'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `0`.',
+                        '',
+                        '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
+                        '|-|-|-|-|',
+                        '| `benchFib10` | `100` ops/sec (`+-20`) | `100` ops/sec (`+-20`) | `1` |',
+                        '',
+                        `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
+                        '',
+                        'CC: @user',
+                    ],
+                },
+                {
+                    it: 'raises an alert with different failure threshold from alert threshold',
+                    config: { ...defaultCfg, failThreshold: 3 },
+                    data: {
+                        lastUpdate,
+                        repoUrl,
+                        entries: {
+                            'Test benchmark': [
+                                {
+                                    commit: commit('prev commit id'),
+                                    date: lastUpdate - 1000,
+                                    tool: 'go',
+                                    benches: [bench('bench_fib_10', 100)],
+                                },
+                            ],
+                        },
+                    },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'go',
+                        benches: [bench('bench_fib_10', 350)], // Exceeds 3.0 failure threshold
+                    },
+                    error: [
+                        '1 of 1 alerts exceeded the failure threshold `3` specified by fail-threshold input:',
+                        '',
+                        '# :warning: **Performance Alert** :warning:',
+                        '',
+                        "Possible performance regression was detected for benchmark **'Test benchmark'**.",
+                        'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
+                        '',
+                        '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
+                        '|-|-|-|-|',
+                        '| `bench_fib_10` | `350` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `3.50` |',
+                        '',
+                        `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
+                        '',
+                        'CC: @user',
+                    ],
+                },
+                {
+                    it: 'does not raise an alert when not exceeding failure threshold',
+                    config: { ...defaultCfg, failThreshold: 3 },
+                    data: {
+                        lastUpdate,
+                        repoUrl,
+                        entries: {
+                            'Test benchmark': [
+                                {
+                                    commit: commit('prev commit id'),
+                                    date: lastUpdate - 1000,
+                                    tool: 'go',
+                                    benches: [bench('bench_fib_10', 100)],
+                                },
+                            ],
+                        },
+                    },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'go',
+                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
+                    },
+                    error: undefined,
+                },
+            ];
 
         for (const t of normalCases) {
             it(t.it, async function () {
@@ -916,6 +917,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
             failOnAlert: true,
             alertCommentCcUsers: [],
             externalDataJsonPath: undefined,
+            readCommitIdFromGit: false,
             maxItemsInChart: null,
             failThreshold: 2.0,
         };
@@ -959,266 +961,266 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
             error?: string[];
             expectedDataBaseDirectory?: string;
         }> = [
-            {
-                it: 'appends new data',
-                config: defaultCfg,
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 135)],
+                {
+                    it: 'appends new data',
+                    config: defaultCfg,
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 135)],
+                    },
+                    gitServerUrl: serverUrl,
+                    gitHistory: gitHistory(),
                 },
-                gitServerUrl: serverUrl,
-                gitHistory: gitHistory(),
-            },
-            {
-                it: 'creates new data file',
-                config: { ...defaultCfg, benchmarkDataDirPath: 'new-data-dir' },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 135)],
+                {
+                    it: 'creates new data file',
+                    config: { ...defaultCfg, benchmarkDataDirPath: 'new-data-dir' },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 135)],
+                    },
+                    gitServerUrl: serverUrl,
+                    gitHistory: gitHistory({ dir: 'new-data-dir' }),
                 },
-                gitServerUrl: serverUrl,
-                gitHistory: gitHistory({ dir: 'new-data-dir' }),
-            },
-            {
-                it: 'appends new data in other repository',
-                config: {
-                    ...defaultCfg,
-                    ghRepository: 'https://github.com/user/other-repo',
-                    benchmarkDataDirPath: 'data-dir',
-                },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 135)],
-                },
-                gitServerUrl: serverUrl,
-                gitHistory: [
-                    ['clone', ['dummy token', 'https://github.com/user/other-repo', './benchmark-data-repository']],
-                    [
-                        'checkout',
+                {
+                    it: 'appends new data in other repository',
+                    config: {
+                        ...defaultCfg,
+                        ghRepository: 'https://github.com/user/other-repo',
+                        benchmarkDataDirPath: 'data-dir',
+                    },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 135)],
+                    },
+                    gitServerUrl: serverUrl,
+                    gitHistory: [
+                        ['clone', ['dummy token', 'https://github.com/user/other-repo', './benchmark-data-repository']],
                         [
-                            'gh-pages',
-                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                            'checkout',
+                            [
+                                'gh-pages',
+                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                            ],
+                        ],
+                        [
+                            'cmd',
+                            [
+                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                                'add',
+                                path.join('data-dir', 'data.js'),
+                            ],
+                        ],
+                        [
+                            'cmd',
+                            [
+                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                                'add',
+                                path.join('data-dir', 'index.html'),
+                            ],
+                        ],
+                        [
+                            'cmd',
+                            [
+                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                                'commit',
+                                '-m',
+                                'add Test benchmark (cargo) benchmark result for current commit id',
+                            ],
+                        ],
+                        [
+                            'push',
+                            [
+                                'dummy token',
+                                'https://github.com/user/other-repo',
+                                'gh-pages',
+                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                            ],
                         ],
                     ],
-                    [
-                        'cmd',
+                    expectedDataBaseDirectory: 'benchmark-data-repository',
+                },
+                {
+                    it: 'creates new data file in other repository',
+                    config: {
+                        ...defaultCfg,
+                        ghRepository: 'https://github.com/user/other-repo',
+                    },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 135)],
+                    },
+                    gitServerUrl: serverUrl,
+                    gitHistory: [
+                        ['clone', ['dummy token', 'https://github.com/user/other-repo', './benchmark-data-repository']],
                         [
-                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                            'add',
-                            path.join('data-dir', 'data.js'),
+                            'checkout',
+                            [
+                                'gh-pages',
+                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                            ],
+                        ],
+                        [
+                            'cmd',
+                            [
+                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                                'add',
+                                path.join('data-dir', 'data.js'),
+                            ],
+                        ],
+                        [
+                            'cmd',
+                            [
+                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                                'add',
+                                path.join('data-dir', 'index.html'),
+                            ],
+                        ],
+                        [
+                            'cmd',
+                            [
+                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                                'commit',
+                                '-m',
+                                'add Test benchmark (cargo) benchmark result for current commit id',
+                            ],
+                        ],
+                        [
+                            'push',
+                            [
+                                'dummy token',
+                                'https://github.com/user/other-repo',
+                                'gh-pages',
+                                ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                            ],
                         ],
                     ],
-                    [
-                        'cmd',
-                        [
-                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                            'add',
-                            path.join('data-dir', 'index.html'),
-                        ],
+                    expectedDataBaseDirectory: 'benchmark-data-repository',
+                },
+                {
+                    it: 'creates new suite in data',
+                    config: defaultCfg,
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('other_bench_foo', 100)],
+                    },
+                    gitServerUrl: serverUrl,
+                    gitHistory: gitHistory(),
+                },
+                {
+                    it: 'does not create index.html if it already exists',
+                    config: { ...defaultCfg, benchmarkDataDirPath: 'with-index-html' },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 100)],
+                    },
+                    gitServerUrl: serverUrl,
+                    gitHistory: gitHistory({ dir: 'with-index-html', addIndexHtml: false }),
+                },
+                {
+                    it: 'does not push to remote when auto-push is off',
+                    config: { ...defaultCfg, autoPush: false },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 135)],
+                    },
+                    gitServerUrl: serverUrl,
+                    gitHistory: gitHistory({ autoPush: false }),
+                },
+                {
+                    it: 'does not push to remote when auto-push is off without token',
+                    config: { ...defaultCfg, autoPush: false, githubToken: undefined },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 135)],
+                    },
+                    gitServerUrl: serverUrl,
+                    gitHistory: gitHistory({ autoPush: false, token: undefined }),
+                },
+                {
+                    it: 'does not fetch remote when github-token is not set for private repo',
+                    config: { ...defaultCfg, autoPush: false, githubToken: undefined },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 135)],
+                    },
+                    gitServerUrl: serverUrl,
+                    gitHistory: gitHistory({ autoPush: false, token: undefined, fetch: false }),
+                    privateRepo: true,
+                },
+                {
+                    it: 'does not fetch remote when skip-fetch-gh-pages is enabled',
+                    config: { ...defaultCfg, skipFetchGhPages: true },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 135)],
+                    },
+                    gitServerUrl: serverUrl,
+                    gitHistory: gitHistory({ fetch: false, skipFetch: true }),
+                },
+                {
+                    it: 'fails when exceeding the threshold',
+                    config: defaultCfg,
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
+                    },
+                    gitServerUrl: serverUrl,
+                    gitHistory: gitHistory(),
+                    error: [
+                        '# :warning: **Performance Alert** :warning:',
+                        '',
+                        "Possible performance regression was detected for benchmark **'Test benchmark'**.",
+                        'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
+                        '',
+                        '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
+                        '|-|-|-|-|',
+                        '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
+                        '',
+                        `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
                     ],
-                    [
-                        'cmd',
-                        [
-                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                            'commit',
-                            '-m',
-                            'add Test benchmark (cargo) benchmark result for current commit id',
-                        ],
-                    ],
-                    [
-                        'push',
-                        [
-                            'dummy token',
-                            'https://github.com/user/other-repo',
-                            'gh-pages',
-                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                        ],
-                    ],
-                ],
-                expectedDataBaseDirectory: 'benchmark-data-repository',
-            },
-            {
-                it: 'creates new data file in other repository',
-                config: {
-                    ...defaultCfg,
-                    ghRepository: 'https://github.com/user/other-repo',
                 },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 135)],
+                {
+                    it: 'sends commit message but does not raise an error when exceeding alert threshold but not exceeding failure threshold',
+                    config: {
+                        ...defaultCfg,
+                        commentOnAlert: true,
+                        githubToken: 'dummy token',
+                        alertThreshold: 2,
+                        failThreshold: 3,
+                    },
+                    added: {
+                        commit: commit('current commit id'),
+                        date: lastUpdate,
+                        tool: 'cargo',
+                        benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold but not exceed 3.0 threshold
+                    },
+                    gitServerUrl: serverUrl,
+                    gitHistory: gitHistory(),
+                    error: undefined,
                 },
-                gitServerUrl: serverUrl,
-                gitHistory: [
-                    ['clone', ['dummy token', 'https://github.com/user/other-repo', './benchmark-data-repository']],
-                    [
-                        'checkout',
-                        [
-                            'gh-pages',
-                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                        ],
-                    ],
-                    [
-                        'cmd',
-                        [
-                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                            'add',
-                            path.join('data-dir', 'data.js'),
-                        ],
-                    ],
-                    [
-                        'cmd',
-                        [
-                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                            'add',
-                            path.join('data-dir', 'index.html'),
-                        ],
-                    ],
-                    [
-                        'cmd',
-                        [
-                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                            'commit',
-                            '-m',
-                            'add Test benchmark (cargo) benchmark result for current commit id',
-                        ],
-                    ],
-                    [
-                        'push',
-                        [
-                            'dummy token',
-                            'https://github.com/user/other-repo',
-                            'gh-pages',
-                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
-                        ],
-                    ],
-                ],
-                expectedDataBaseDirectory: 'benchmark-data-repository',
-            },
-            {
-                it: 'creates new suite in data',
-                config: defaultCfg,
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('other_bench_foo', 100)],
-                },
-                gitServerUrl: serverUrl,
-                gitHistory: gitHistory(),
-            },
-            {
-                it: 'does not create index.html if it already exists',
-                config: { ...defaultCfg, benchmarkDataDirPath: 'with-index-html' },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 100)],
-                },
-                gitServerUrl: serverUrl,
-                gitHistory: gitHistory({ dir: 'with-index-html', addIndexHtml: false }),
-            },
-            {
-                it: 'does not push to remote when auto-push is off',
-                config: { ...defaultCfg, autoPush: false },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 135)],
-                },
-                gitServerUrl: serverUrl,
-                gitHistory: gitHistory({ autoPush: false }),
-            },
-            {
-                it: 'does not push to remote when auto-push is off without token',
-                config: { ...defaultCfg, autoPush: false, githubToken: undefined },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 135)],
-                },
-                gitServerUrl: serverUrl,
-                gitHistory: gitHistory({ autoPush: false, token: undefined }),
-            },
-            {
-                it: 'does not fetch remote when github-token is not set for private repo',
-                config: { ...defaultCfg, autoPush: false, githubToken: undefined },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 135)],
-                },
-                gitServerUrl: serverUrl,
-                gitHistory: gitHistory({ autoPush: false, token: undefined, fetch: false }),
-                privateRepo: true,
-            },
-            {
-                it: 'does not fetch remote when skip-fetch-gh-pages is enabled',
-                config: { ...defaultCfg, skipFetchGhPages: true },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 135)],
-                },
-                gitServerUrl: serverUrl,
-                gitHistory: gitHistory({ fetch: false, skipFetch: true }),
-            },
-            {
-                it: 'fails when exceeding the threshold',
-                config: defaultCfg,
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold
-                },
-                gitServerUrl: serverUrl,
-                gitHistory: gitHistory(),
-                error: [
-                    '# :warning: **Performance Alert** :warning:',
-                    '',
-                    "Possible performance regression was detected for benchmark **'Test benchmark'**.",
-                    'Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.',
-                    '',
-                    '| Benchmark suite | Current: current commit id | Previous: prev commit id | Ratio |',
-                    '|-|-|-|-|',
-                    '| `bench_fib_10` | `210` ns/iter (`± 20`) | `100` ns/iter (`± 20`) | `2.10` |',
-                    '',
-                    `This comment was automatically generated by [workflow](${serverUrl}/user/repo/actions?query=workflow%3AWorkflow%20name) using [github-action-benchmark](https://github.com/marketplace/actions/continuous-benchmark).`,
-                ],
-            },
-            {
-                it: 'sends commit message but does not raise an error when exceeding alert threshold but not exceeding failure threshold',
-                config: {
-                    ...defaultCfg,
-                    commentOnAlert: true,
-                    githubToken: 'dummy token',
-                    alertThreshold: 2,
-                    failThreshold: 3,
-                },
-                added: {
-                    commit: commit('current commit id'),
-                    date: lastUpdate,
-                    tool: 'cargo',
-                    benches: [bench('bench_fib_10', 210)], // Exceeds 2.0 threshold but not exceed 3.0 threshold
-                },
-                gitServerUrl: serverUrl,
-                gitHistory: gitHistory(),
-                error: undefined,
-            },
-        ];
+            ];
         for (const t of normalCases) {
             // FIXME: can't use `it.each` currently as tests running in parallel interfere with each other
             it(t.it, async function () {
@@ -1311,30 +1313,30 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
             pushErrorMessage: string;
             pushErrorCount: number;
         }> = [
-            ...[1, 2].map((retries) => ({
-                it: `updates data successfully after ${retries} retries`,
-                pushErrorMessage: '... [remote rejected] ...',
-                pushErrorCount: retries,
-            })),
-            {
-                it: `gives up updating data after ${maxRetries} retries with an error`,
-                pushErrorMessage: '... [remote rejected] ...',
-                pushErrorCount: maxRetries,
-                error: /Auto-push failed 3 times since the remote branch gh-pages rejected pushing all the time/,
-            },
-            {
-                it: `gives up updating data after ${maxRetries} retries with an error containing "[rejected]" in message`,
-                pushErrorMessage: '... [rejected] ...',
-                pushErrorCount: maxRetries,
-                error: /Auto-push failed 3 times since the remote branch gh-pages rejected pushing all the time/,
-            },
-            {
-                it: 'handles an unexpected error without retry',
-                pushErrorMessage: 'Some fatal error',
-                pushErrorCount: 1,
-                error: /Some fatal error/,
-            },
-        ];
+                ...[1, 2].map((retries) => ({
+                    it: `updates data successfully after ${retries} retries`,
+                    pushErrorMessage: '... [remote rejected] ...',
+                    pushErrorCount: retries,
+                })),
+                {
+                    it: `gives up updating data after ${maxRetries} retries with an error`,
+                    pushErrorMessage: '... [remote rejected] ...',
+                    pushErrorCount: maxRetries,
+                    error: /Auto-push failed 3 times since the remote branch gh-pages rejected pushing all the time/,
+                },
+                {
+                    it: `gives up updating data after ${maxRetries} retries with an error containing "[rejected]" in message`,
+                    pushErrorMessage: '... [rejected] ...',
+                    pushErrorCount: maxRetries,
+                    error: /Auto-push failed 3 times since the remote branch gh-pages rejected pushing all the time/,
+                },
+                {
+                    it: 'handles an unexpected error without retry',
+                    pushErrorMessage: 'Some fatal error',
+                    pushErrorCount: 1,
+                    error: /Some fatal error/,
+                },
+            ];
 
         for (const t of retryCases) {
             it(t.it, async function () {


### PR DESCRIPTION
Attempt to bring #23 again. 

This can be used to run without cache (running benchmark in base branch first and then running in PR branch).

I tried to address feedbacks in that PR:

Example of usage: https://github.com/morenol/fluvio/pull/25