### PR TITLE
Fix for small documentation error for save-data-file argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ If it is set to `true`, this action will leave a commit comment comparing the cu
 - Type: Boolean
 - Default: `true`
 
-If it is set to `true`, this action will not save the current benchmark to the external data file.
+If it is set to `false`, this action will not save the current benchmark to the external data file.
 You can use this option to set up your action to compare the benchmarks between PR and base branch.
 
 #### `alert-threshold` (Optional)


### PR DESCRIPTION
Hi,

I was flustered by the documentation of the `save-data-file` argument. It states that if `save-data-file` is `true`, the current benchmark will **not** be saved to the external data file, which doesn't make much sense given the name of the argument. After running the action in one of my repos, I realized that this is a mistake in the documentation. 

Because this is such a small fix, I didn't bother raising an issue beforehand, hope that's alright.