### PR TITLE
fix: use `commit.id` over `commit` object

### DIFF
--- a/src/write.ts
+++ b/src/write.ts
@@ -556,11 +556,11 @@ export async function writeSummary(bench: Benchmark, config: Config): Promise<vo
             header: true,
         },
         {
-            data: `Current: "${bench.commit}"`,
+            data: `Current: "${bench.commit.id}"`,
             header: true,
         },
         {
-            data: `Previous: "${prevBench.commit}"`,
+            data: `Previous: "${prevBench.commit.id}"`,
             header: true,
         },
         {


### PR DESCRIPTION
Currently we are providing the `commit` object as is instead of the
commit ID which is the actual string.

<img width="1130" alt="image" src="https://user-images.githubusercontent.com/34756077/223233314-b31c1afa-6b4a-4a74-8056-cf98d424f55d.png">

Refer for example: https://github.com/infinyon/fluvio/actions/runs/4347865829