### PR TITLE
Enable user to specify the git ref being tested

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,9 @@ inputs:
   github-token:
     description: 'GitHub API token to pull/push GitHub pages branch and deploy GitHub pages. For public repository, this must be personal access token for now. Please read README.md for more details'
     required: false
+  ref:
+    description: 'optional Ref to use when finding commit'
+    required: false
   auto-push:
     description: 'Push GitHub Pages branch to remote automatically. This option requires github-token input'
     required: false

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,7 @@ export interface Config {
     alertCommentCcUsers: string[];
     externalDataJsonPath: string | undefined;
     maxItemsInChart: number | null;
+    ref: string | undefined;
 }
 
 export const VALID_TOOLS = [
@@ -226,6 +227,7 @@ export async function configFromJobInput(): Promise<Config> {
     let benchmarkDataDirPath: string = core.getInput('benchmark-data-dir-path');
     const name: string = core.getInput('name');
     const githubToken: string | undefined = core.getInput('github-token') || undefined;
+    const ref: string | undefined = core.getInput('ref') || undefined;
     const autoPush = getBoolInput('auto-push');
     const skipFetchGhPages = getBoolInput('skip-fetch-gh-pages');
     const commentAlways = getBoolInput('comment-always');
@@ -284,5 +286,6 @@ export async function configFromJobInput(): Promise<Config> {
         externalDataJsonPath,
         maxItemsInChart,
         failThreshold,
+        ref,
     };
 }

--- a/test/extract.spec.ts
+++ b/test/extract.spec.ts
@@ -14,9 +14,11 @@ const dummyWebhookPayload = {
     },
 } as { [key: string]: any };
 let dummyCommitData = {};
+let lastCommitRequestData = {};
 class DummyGitHub {
     repos = {
-        getCommit: () => {
+        getCommit: (data: any) => {
+            lastCommitRequestData = data;
             return {
                 status: 200,
                 data: dummyCommitData,
@@ -541,7 +543,7 @@ describe('extractResult()', function () {
         A.equal(commit.url, 'https://github.com/dummy/repo/pull/1/commits/abcdef0123456789');
     });
 
-    it('collects the commit information from current head via REST API as fallback when githubToken is provided', async function () {
+    it('collects the commit information from specified ref via REST API as fallback when githubToken and ref provided', async function () {
         dummyGitHubContext.payload = {};
         dummyCommitData = {
             author: {
@@ -572,6 +574,7 @@ describe('extractResult()', function () {
             tool: 'go',
             outputFilePath,
             githubToken: 'abcd1234',
+            ref: 'refs/pull/123/head',
         } as Config;
 
         const { commit } = await extractResult(config);
@@ -592,6 +595,70 @@ describe('extractResult()', function () {
                 email: 'committer@testdummy.com',
             },
         };
+        A.deepEqual(lastCommitRequestData, {
+            owner: 'dummy',
+            repo: 'repo',
+            ref: 'refs/pull/123/head',
+        });
+        A.deepEqual(commit, expectedCommit);
+    });
+
+    it('collects the commit information from current head via REST API as fallback when githubToken is provided', async function () {
+        dummyGitHubContext.payload = {};
+        dummyCommitData = {
+            author: {
+                login: 'testAuthorLogin',
+            },
+            committer: {
+                login: 'testCommitterLogin',
+            },
+            commit: {
+                author: {
+                    name: 'test author',
+                    date: 'author updated at timestamp',
+                    email: 'author@testdummy.com',
+                },
+                committer: {
+                    name: 'test committer',
+                    // We use the `author.date` instead.
+                    // date: 'committer updated at timestamp',
+                    email: 'committer@testdummy.com',
+                },
+                message: 'test message',
+            },
+            sha: 'abcd1235',
+            html_url: 'https://github.com/dymmy/repo/commit/abcd1234',
+        };
+        const outputFilePath = path.join(__dirname, 'data', 'extract', 'go_output.txt');
+        const config = {
+            tool: 'go',
+            outputFilePath,
+            githubToken: 'abcd1234',
+        } as Config;
+
+        const { commit } = await extractResult(config);
+
+        const expectedCommit = {
+            id: 'abcd1235',
+            message: 'test message',
+            timestamp: 'author updated at timestamp',
+            url: 'https://github.com/dymmy/repo/commit/abcd1234',
+            author: {
+                name: 'test author',
+                username: 'testAuthorLogin',
+                email: 'author@testdummy.com',
+            },
+            committer: {
+                name: 'test committer',
+                username: 'testCommitterLogin',
+                email: 'committer@testdummy.com',
+            },
+        };
+        A.deepEqual(lastCommitRequestData, {
+            owner: 'dummy',
+            repo: 'repo',
+            ref: 'abcd1234',
+        });
         A.deepEqual(commit, expectedCommit);
     });
 

--- a/test/write.spec.ts
+++ b/test/write.spec.ts
@@ -219,6 +219,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
             externalDataJsonPath: dataJson,
             maxItemsInChart: null,
             failThreshold: 2.0,
+            ref: undefined,
         };
 
         const savedRepository = {
@@ -920,6 +921,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
             externalDataJsonPath: undefined,
             maxItemsInChart: null,
             failThreshold: 2.0,
+            ref: undefined,
         };
 
         function gitHistory(


### PR DESCRIPTION
The ref will be used preferentially (if specified) when looking up the details of the commit to record the results against.

Why:
When used to record results from a performance test run triggered by a comment on a PR, the results were recorded against the head commit of main, not the tested commit. The workflow checked out the PR's ref and ran tests against this. This change allows users to specify the tested ref to record benchmark results against.

Example usage:
```
with:
  ref: refs/pull/${{ github.event.issue.number }}/head
```

Closes #157