### PR TITLE
getServerUrl refers to the GITHUB_SERVER_URL environment variable

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -39,9 +39,10 @@ async function capture(cmd: string, args: string[]): Promise<ExecResult> {
 }
 
 export function getServerUrlObj(repositoryUrl: string | undefined): URL {
-    const urlValue = repositoryUrl && repositoryUrl.trim().length > 0
-        ? repositoryUrl
-        : process.env['GITHUB_SERVER_URL'] || DEFAULT_GITHUB_URL;
+    const urlValue =
+        repositoryUrl && repositoryUrl.trim().length > 0
+            ? repositoryUrl
+            : process.env['GITHUB_SERVER_URL'] ?? DEFAULT_GITHUB_URL;
     return new URL(urlValue);
 }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -39,9 +39,9 @@ async function capture(cmd: string, args: string[]): Promise<ExecResult> {
 }
 
 export function getServerUrlObj(repositoryUrl: string | undefined): URL {
-    const urlValue = url && url.trim().length > 0
-        ? url
-        : process.env['GITHUB_SERVER_URL'] || DEFAULT_GITHUB_URL
+    const urlValue = repositoryUrl && repositoryUrl.trim().length > 0
+        ? repositoryUrl
+        : process.env['GITHUB_SERVER_URL'] || DEFAULT_GITHUB_URL;
     return new URL(urlValue);
 }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -38,14 +38,20 @@ async function capture(cmd: string, args: string[]): Promise<ExecResult> {
     }
 }
 
+export function getServerUrlObj(repositoryUrl: string | undefined): URL {
+  const urlValue =
+    url && url.trim().length > 0
+      ? url
+      : process.env['GITHUB_SERVER_URL'] || DEFAULT_GITHUB_URL
+    return new URL(urlValue);
+}
+
 export function getServerUrl(repositoryUrl: string | undefined): string {
-    const urlObj = repositoryUrl ? new URL(repositoryUrl) : new URL(DEFAULT_GITHUB_URL);
-    return repositoryUrl ? urlObj.origin : DEFAULT_GITHUB_URL;
+    return getServerUrlObj(repositoryUrl).origin;
 }
 
 export function getServerName(repositoryUrl: string | undefined): string {
-    const urlObj = repositoryUrl ? new URL(repositoryUrl) : new URL(DEFAULT_GITHUB_URL);
-    return repositoryUrl ? urlObj.hostname : DEFAULT_GITHUB_URL.replace('https://', '');
+    return getServerUrlObj(repositoryUrl).hostname;
 }
 
 export async function cmd(additionalGitOptions: string[], ...args: string[]): Promise<string> {

--- a/src/git.ts
+++ b/src/git.ts
@@ -39,10 +39,9 @@ async function capture(cmd: string, args: string[]): Promise<ExecResult> {
 }
 
 export function getServerUrlObj(repositoryUrl: string | undefined): URL {
-  const urlValue =
-    url && url.trim().length > 0
-      ? url
-      : process.env['GITHUB_SERVER_URL'] || DEFAULT_GITHUB_URL
+    const urlValue = url && url.trim().length > 0
+        ? url
+        : process.env['GITHUB_SERVER_URL'] || DEFAULT_GITHUB_URL
     return new URL(urlValue);
 }
 


### PR DESCRIPTION
GitHub Enterprise Server 3.7 or earlier fails to resolve the server URL because the schedule event payload does not include repository.

Since the server URL can be got with the GITHUB_SERVER_URL environment variable, it is now referenced if it cannot be got from payload.

https://docs.github.com/en/enterprise-server@3.8/admin/release-notes

> For scheduled runs of GitHub Actions workflows, users will see additional information about the repository, organization, and enterprise within the payload for github.event.