### PR TITLE
use github actions bot

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -54,9 +54,9 @@ export async function cmd(additionalGitOptions: string[], ...args: string[]): Pr
     const userArgs = [
         ...additionalGitOptions,
         '-c',
-        'user.name=github-action-benchmark',
+        'user.name=github-actions[bot]',
         '-c',
-        'user.email=github@users.noreply.github.com',
+        'user.email=github-actions[bot]@users.noreply.github.com',
         '-c',
         `http.${serverUrl}/.extraheader=`, // This config is necessary to support actions/checkout@v2 (#9)
     ];


### PR DESCRIPTION
This will allow for the github user not to show up in a projects insights.

If you have a look at the project insights, you will see that the commits from github-action-benchmark are counted which makes the rest of the stats hard to compare. This PR changes the git user to the one provided by GitHub actions used for bot accounts for things like deployment.