### PR TITLE
fix: 213 summary-always and gh-repository don't work together

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import { configFromJobInput } from './config';
 import { extractResult } from './extract';
-import { writeBenchmark, writeSummary } from './write';
+import { writeBenchmark } from './write';
 
 async function main() {
     const config = await configFromJobInput();
@@ -11,10 +11,6 @@ async function main() {
     core.debug(`Benchmark result was extracted: ${bench}`);
 
     await writeBenchmark(bench, config);
-
-    if (config.summaryAlways) {
-        await writeSummary(bench, config);
-    }
 
     console.log('github-action-benchmark was run successfully!', '\nData:', bench);
 }


### PR DESCRIPTION
* move summary logic into writeBenchmark function so that we only clone the separate repo once

fixes #213 