### PR TITLE
Add Bencher to Related actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,10 @@ Every release will appear on your GitHub notifications page.
 - [lighthouse-ci-action][] is an action for [Lighthouse CI][lighthouse-ci]. If you're measuring performance
   of your web application, using Lighthouse CI and lighthouse-ci-action would be better than using this
   action.
+- [bencher][] is an action for the [Bencher CLI][].
+  If your project requires the ability to measure performance across multiple branches,
+  test environments, or for pull requests from forks,
+  Bencher may be better than using this action.
 
 
 
@@ -669,6 +673,8 @@ Every release will appear on your GitHub notifications page.
 [jmh]: https://openjdk.java.net/projects/code-tools/jmh/
 [lighthouse-ci-action]: https://github.com/treosh/lighthouse-ci-action
 [lighthouse-ci]: https://github.com/GoogleChrome/lighthouse-ci
+[bencher]: https://github.com/bencherdev/bencher
+[Bencher CLI]: https://bencher.dev/docs/how-to/install-cli/#github-actions
 [BenchmarkTools.jl]: https://github.com/JuliaCI/BaseBenchmarks.jl
 [benchmarkdotnet]: https://benchmarkdotnet.org
 [benchmarkdotnet-badge]: https://github.com/benchmark-action/github-action-benchmark/actions/workflows/benchmarkdotnet.yml/badge.svg


### PR DESCRIPTION
Hey `github-action-benchmark` team,
Thank you for creating and maintaining this GitHub Action! 
A couple of years ago, I needed to track performance in CI. Unfortunately, I was not able to use GitHub, and it needed to work on-prem. So I had to roll my own solution. This eventually grew to be a tool called [Bencher](https://github.com/bencherdev/bencher).

The backend for Bencher is an open source API server with auth, so it can handle a couple of things that this action cannot, like safely benchmarking pull requests from forks, tracking multiple branches side-by-side, etc.

If you all would prefer to not merge this PR, I would totally understand. Thank you again for all the hard work.
You all's test files have been super helpful for building out the benchmark harness adapters in Bencher.
I have a shoutout to you all [at the bottom of this section](https://bencher.dev/docs/reference/prior-art/#benchmark-tracking-tools) as a thank you!
