### PR TITLE
fix: Support sub-nanosecond precision on Cargo benchmarks

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -315,7 +315,7 @@ function extractCargoResult(output: string): BenchmarkResult[] {
     const ret = [];
     // Example:
     //   test bench_fib_20 ... bench:      37,174 ns/iter (+/- 7,527)
-    const reExtract = /^test (.+)\s+\.\.\. bench:\s+([0-9,]+) ns\/iter \(\+\/- ([0-9,]+)\)$/;
+    const reExtract = /^test (.+)\s+\.\.\. bench:\s+([0-9,.]+) ns\/iter \(\+\/- ([0-9,.]+)\)$/;
     const reComma = /,/g;
 
     for (const line of lines) {


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/124774, Rust changed the output of benchmarks to contain sub-nanosecond precision. This was first published in `nightly-2024-05-11` which started breaking CI that used github-action-benchmark since it couldn't find any benchmarks in an output file.