### PR TITLE
Add typings and validation workflow

### DIFF
--- a/.github/workflows/validate-action-typings.yml
+++ b/.github/workflows/validate-action-typings.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
+    branches: [master]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/validate-action-typings.yml
+++ b/.github/workflows/validate-action-typings.yml
@@ -1,0 +1,14 @@
+name: Validate action typings
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  validate-typings:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: typesafegithub/github-actions-typing@v1

--- a/action-types.yml
+++ b/action-types.yml
@@ -4,18 +4,18 @@ inputs:
   tool:
     type: enum
     allowed-values:
-    - cargo
-    - go
-    - benchmarkjs
-    - pytest
-    - googlecpp
-    - catch2
-    - julia
-    - jmh
-    - benchmarkdotnet
-    - benchmarkluau
-    - customBiggerIsBetter
-    - customSmallerIsBetter
+      - cargo
+      - go
+      - benchmarkjs
+      - pytest
+      - googlecpp
+      - catch2
+      - julia
+      - jmh
+      - benchmarkdotnet
+      - benchmarkluau
+      - customBiggerIsBetter
+      - customSmallerIsBetter
   output-file-path:
     type: string
   gh-pages-branch:

--- a/action-types.yml
+++ b/action-types.yml
@@ -1,0 +1,57 @@
+inputs:
+  name:
+    type: string
+  tool:
+    type: enum
+    allowed-values:
+    - cargo
+    - go
+    - benchmarkjs
+    - pytest
+    - googlecpp
+    - catch2
+    - julia
+    - jmh
+    - benchmarkdotnet
+    - benchmarkluau
+    - customBiggerIsBetter
+    - customSmallerIsBetter
+  output-file-path:
+    type: string
+  gh-pages-branch:
+    type: string
+  gh-repository:
+    type: string
+  benchmark-data-dir-path:
+    type: string
+  github-token:
+    type: string
+  ref:
+    type: string
+  auto-push:
+    type: boolean
+  skip-fetch-gh-pages:
+    type: boolean
+  comment-always:
+    type: boolean
+  summary-always:
+    type: boolean
+  save-data-file:
+    type: boolean
+  comment-on-alert:
+    type: boolean
+  alert-threshold:
+    type: string
+  fail-on-alert:
+    type: boolean
+  fail-threshold:
+    type: string
+  alert-comment-cc-users:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  external-data-json-path:
+    type: string
+  max-items-in-chart:
+    type: integer


### PR DESCRIPTION
Add typings using https://github.com/typesafegithub/github-actions-typing, so that other tools can make use of them.