### PR TITLE
feat: allow to parse generic cargo bench/criterion units

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -315,7 +315,8 @@ function extractCargoResult(output: string): BenchmarkResult[] {
     const ret = [];
     // Example:
     //   test bench_fib_20 ... bench:      37,174.25 ns/iter (+/- 7,527.43)
-    const reExtract = /^test (.+)\s+\.\.\. bench:\s+([0-9,.]+) ns\/iter \(\+\/- ([0-9,.]+)\)$/;
+    
+    const reExtract = /^test (.+)\s+\.\.\. bench:\s+([0-9,.]+) (\w+\/\w+) \(\+\/- ([0-9,.]+)\)$/;
     const reComma = /,/g;
 
     for (const line of lines) {
@@ -326,13 +327,14 @@ function extractCargoResult(output: string): BenchmarkResult[] {
 
         const name = m[1].trim();
         const value = parseFloat(m[2].replace(reComma, ''));
-        const range = m[3].replace(reComma, '');
+        const unit = m[3].trim();
+        const range = m[4].replace(reComma, '');
 
         ret.push({
             name,
             value,
             range: `± ${range}`,
-            unit: 'ns/iter',
+            unit: unit,
         });
     }
 

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -313,9 +313,6 @@ async function getCommit(githubToken?: string, ref?: string): Promise<Commit> {
 function extractCargoResult(output: string): BenchmarkResult[] {
     const lines = output.split(/\r?\n/g);
     const ret = [];
-    // Example:
-    //   test bench_fib_20 ... bench:      37,174.25 ns/iter (+/- 7,527.43)
-    
     const reExtract = /^test (.+)\s+\.\.\. bench:\s+([0-9,.]+) (\w+\/\w+) \(\+\/- ([0-9,.]+)\)$/;
     const reComma = /,/g;
 

--- a/test/__snapshots__/extract.spec.ts.snap
+++ b/test/__snapshots__/extract.spec.ts.snap
@@ -134,6 +134,53 @@ exports[`extractResult() extracts benchmark output from cargo - cargo_output.txt
 }
 `;
 
+exports[`extractResult() extracts benchmark output from cargo - cargo_output_units.txt 1`] = `
+{
+  "benches": [
+    {
+      "name": "cmov",
+      "range": "± 14",
+      "unit": "cycles/iter",
+      "value": 2835,
+    },
+    {
+      "name": "cmov2",
+      "range": "± 19",
+      "unit": "cycles/iter",
+      "value": 2845,
+    },
+    {
+      "name": "mov",
+      "range": "± 17",
+      "unit": "cycles/iter",
+      "value": 1508,
+    },
+    {
+      "name": "upload",
+      "range": "± 420",
+      "unit": "MS/s",
+      "value": 1911,
+    },
+    {
+      "name": "download",
+      "range": "± 69",
+      "unit": "MS/s",
+      "value": 9001,
+    },
+  ],
+  "commit": {
+    "author": null,
+    "committer": null,
+    "id": "123456789abcdef",
+    "message": "this is dummy",
+    "timestamp": "dummy timestamp",
+    "url": "https://github.com/dummy/repo",
+  },
+  "date": 1712131503296,
+  "tool": "cargo",
+}
+`;
+
 exports[`extractResult() extracts benchmark output from cargo - cargo_output2.txt 1`] = `
 {
   "benches": [

--- a/test/data/extract/cargo_output_units.txt
+++ b/test/data/extract/cargo_output_units.txt
@@ -1,0 +1,9 @@
+test cmov ... bench:        2835 cycles/iter (+/- 14)
+
+test cmov2 ... bench:        2845 cycles/iter (+/- 19)
+
+test mov ... bench:        1508 cycles/iter (+/- 17)
+
+test upload ... bench:        1911 MS/s (+/- 420)
+
+test download ... bench:        9001 MS/s (+/- 69)

--- a/test/extract.spec.ts
+++ b/test/extract.spec.ts
@@ -73,6 +73,10 @@ describe('extractResult()', function () {
         },
         {
             tool: 'cargo',
+            file: 'cargo_output_units.txt',
+        },
+        {
+            tool: 'cargo',
             file: 'criterion_output.txt',
         },
         {


### PR DESCRIPTION
Previously the unit 'ns/iter' was hardcoded:
```
test bench_fib_10 ... bench:         148.70 ns/iter (+/- 2.21)
test bench_fib_20 ... bench:      18,794.12 ns/iter (+/- 440.25)
```

This PR allows any unit:
```
test cmov ... bench:        2835 cycles/iter (+/- 14)
test cmov2 ... bench:        2845 cycles/iter (+/- 19)
test mov ... bench:        1508 cycles/iter (+/- 17)
```
