### PR TITLE
Add `ssh-key` as an alternative to `github-token`

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,29 @@ option.
     alert-comment-cc-users: '@rhysd'
 ```
 
+### SSH Deploy Key Example
+
+This example shows how to use an SSH deploy key for authentication when deploying to GitHub Pages. In order
+to use this, you need to add the [SSH deploy key to your organization secrets](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys).
+
+```yaml
+- name: Store benchmark result
+  uses: benchmark-action/github-action-benchmark@v1
+  with:
+    tool: 'cargo'
+    output-file-path: output.txt
+    external-data-json-path: ./cache/benchmark-data.json
+    fail-on-alert: true
+    # SSH private key for authentication
+    ssh-key: ${{ secrets.SSH_DEPLOY_KEY }}
+    # Enable alert commit comment
+    comment-on-alert: true
+    # Enable Job Summary for PRs
+    summary-always: true
+    # Mention @rhysd in the commit comment
+    alert-comment-cc-users: '@rhysd'
+```
+
 ### Charts on GitHub Pages
 
 It is useful to see how the benchmark results changed on each change in time-series charts. This action
@@ -532,6 +555,12 @@ which means there is no limit.
 
 If set to `true`, the workflow will skip fetching branch defined with the `gh-pages-branch` variable.
 
+#### `ssh-key` (Optional)
+
+- Type: String
+- Default: N/A
+
+SSH private key used for authentication when pushing to a repository. This key should be provided if you prefer to use SSH instead of a GitHub token for authentication. Ensure that the key is kept secure and is only accessible to authorized users.
 
 ### Action outputs
 

--- a/action-types.yml
+++ b/action-types.yml
@@ -26,6 +26,8 @@ inputs:
     type: string
   github-token:
     type: string
+  ssh-key:
+    type: string
   ref:
     type: string
   auto-push:

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,10 @@ inputs:
     required: true
     default: 'dev/bench'
   github-token:
-    description: 'GitHub API token to pull/push GitHub pages branch and deploy GitHub pages. For public repository, this must be personal access token for now. Please read README.md for more details'
+    description: 'GitHub API token to pull/push GitHub pages branch and deploy GitHub pages. For public repository, this must be personal access token for now. Please read README.md for more details. Not required if using ssh-key.'
+    required: false
+  ssh-key:
+    description: 'SSH private key for Git operations. Alternative to github-token. The key should have push access to the repository (usually as a deploy key).'
     required: false
   ref:
     description: 'optional Ref to use when finding commit'

--- a/src/git.ts
+++ b/src/git.ts
@@ -58,21 +58,6 @@ export function getServerName(repositoryUrl: string | undefined): string {
     return getServerUrlObj(repositoryUrl).hostname;
 }
 
-function getCurrentRepoRemoteUrl(token: string | undefined): string {
-    const { repo, owner } = github.context.repo;
-    const serverName = getServerName(github.context.payload.repository?.html_url);
-    return getRepoRemoteUrl(token, `${serverName}/${owner}/${repo}`);
-}
-
-function getRepoRemoteUrl(token: string | undefined, repoUrl: string): string {
-    if (!token) {
-        // Use SSH format when no token is provided
-        const [serverName, owner, repo] = repoUrl.split('/');
-        return `git@${serverName}:${owner}/${repo}.git`;
-    }
-    return `https://x-access-token:${token}@${repoUrl}.git`;
-}
-
 async function setupSshKey(): Promise<void> {
     const sshKey = core.getInput('ssh-key');
     if (!sshKey) {
@@ -114,6 +99,21 @@ export async function cmd(additionalGitOptions: string[], ...args: string[]): Pr
         throw new Error(`Command 'git ${args.join(' ')}' failed: ${JSON.stringify(res)}`);
     }
     return res.stdout;
+}
+
+function getCurrentRepoRemoteUrl(token: string | undefined): string {
+    const { repo, owner } = github.context.repo;
+    const serverName = getServerName(github.context.payload.repository?.html_url);
+    return getRepoRemoteUrl(token, `${serverName}/${owner}/${repo}`);
+}
+
+function getRepoRemoteUrl(token: string | undefined, repoUrl: string): string {
+    if (!token) {
+        // Use SSH format when no token is provided
+        const [serverName, owner, repo] = repoUrl.split('/');
+        return `git@${serverName}:${owner}/${repo}.git`;
+    }
+    return `https://x-access-token:${token}@${repoUrl}.git`;
 }
 
 export async function push(

--- a/src/git.ts
+++ b/src/git.ts
@@ -2,8 +2,12 @@ import { exec } from '@actions/exec';
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 import { URL } from 'url';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
 
 const DEFAULT_GITHUB_URL = 'https://github.com';
+const SSH_KEY_PATH = path.join(os.homedir(), '.ssh', 'github_action_key');
 
 interface ExecResult {
     stdout: string;
@@ -54,6 +58,45 @@ export function getServerName(repositoryUrl: string | undefined): string {
     return getServerUrlObj(repositoryUrl).hostname;
 }
 
+function getCurrentRepoRemoteUrl(token: string | undefined): string {
+    const { repo, owner } = github.context.repo;
+    const serverName = getServerName(github.context.payload.repository?.html_url);
+    return getRepoRemoteUrl(token, `${serverName}/${owner}/${repo}`);
+}
+
+function getRepoRemoteUrl(token: string | undefined, repoUrl: string): string {
+    if (!token) {
+        // Use SSH format when no token is provided
+        const [serverName, owner, repo] = repoUrl.split('/');
+        return `git@${serverName}:${owner}/${repo}.git`;
+    }
+    return `https://x-access-token:${token}@${repoUrl}.git`;
+}
+
+async function setupSshKey(): Promise<void> {
+    const sshKey = core.getInput('ssh-key');
+    if (!sshKey) {
+        return;
+    }
+
+    // Ensure .ssh directory exists
+    const sshDir = path.dirname(SSH_KEY_PATH);
+    if (!fs.existsSync(sshDir)) {
+        fs.mkdirSync(sshDir, { recursive: true });
+    }
+
+    // Write SSH key
+    fs.writeFileSync(SSH_KEY_PATH, sshKey, { mode: 0o600 });
+
+    // Configure Git to use SSH key
+    await cmd(
+        [],
+        'config',
+        'core.sshCommand',
+        `ssh -i ${SSH_KEY_PATH} -o StrictHostKeyChecking=no`,
+    );
+}
+
 export async function cmd(additionalGitOptions: string[], ...args: string[]): Promise<string> {
     core.debug(`Executing Git: ${args.join(' ')}`);
     const serverUrl = getServerUrl(github.context.payload.repository?.html_url);
@@ -73,24 +116,18 @@ export async function cmd(additionalGitOptions: string[], ...args: string[]): Pr
     return res.stdout;
 }
 
-function getCurrentRepoRemoteUrl(token: string): string {
-    const { repo, owner } = github.context.repo;
-    const serverName = getServerName(github.context.payload.repository?.html_url);
-    return getRepoRemoteUrl(token, `${serverName}/${owner}/${repo}`);
-}
-
-function getRepoRemoteUrl(token: string, repoUrl: string): string {
-    return `https://x-access-token:${token}@${repoUrl}.git`;
-}
-
 export async function push(
-    token: string,
+    token: string | undefined,
     repoUrl: string | undefined,
     branch: string,
     additionalGitOptions: string[] = [],
     ...options: string[]
 ): Promise<string> {
-    core.debug(`Executing 'git push' to branch '${branch}' with token and options '${options.join(' ')}'`);
+    core.debug(`Executing 'git push' to branch '${branch}' with ${token ? 'token' : 'SSH key'} and options '${options.join(' ')}'`);
+
+    if (!token) {
+        await setupSshKey();
+    }
 
     const remote = repoUrl ? getRepoRemoteUrl(token, repoUrl) : getCurrentRepoRemoteUrl(token);
     let args = ['push', remote, `${branch}:${branch}`, '--no-verify'];
@@ -107,9 +144,13 @@ export async function pull(
     additionalGitOptions: string[] = [],
     ...options: string[]
 ): Promise<string> {
-    core.debug(`Executing 'git pull' to branch '${branch}' with token and options '${options.join(' ')}'`);
+    core.debug(`Executing 'git pull' on branch '${branch}' with ${token ? 'token' : 'SSH key'} and options '${options.join(' ')}'`);
 
-    const remote = token !== undefined ? getCurrentRepoRemoteUrl(token) : 'origin';
+    if (!token) {
+        await setupSshKey();
+    }
+
+    const remote = getCurrentRepoRemoteUrl(token);
     let args = ['pull', remote, branch];
     if (options.length > 0) {
         args = args.concat(options);
@@ -124,10 +165,14 @@ export async function fetch(
     additionalGitOptions: string[] = [],
     ...options: string[]
 ): Promise<string> {
-    core.debug(`Executing 'git fetch' for branch '${branch}' with token and options '${options.join(' ')}'`);
+    core.debug(`Executing 'git fetch' on branch '${branch}' with ${token ? 'token' : 'SSH key'} and options '${options.join(' ')}'`);
 
-    const remote = token !== undefined ? getCurrentRepoRemoteUrl(token) : 'origin';
-    let args = ['fetch', remote, `${branch}:${branch}`];
+    if (!token) {
+        await setupSshKey();
+    }
+
+    const remote = getCurrentRepoRemoteUrl(token);
+    let args = ['fetch', remote, branch];
     if (options.length > 0) {
         args = args.concat(options);
     }
@@ -136,13 +181,17 @@ export async function fetch(
 }
 
 export async function clone(
-    token: string,
+    token: string | undefined,
     ghRepository: string,
     baseDirectory: string,
     additionalGitOptions: string[] = [],
     ...options: string[]
 ): Promise<string> {
-    core.debug(`Executing 'git clone' to directory '${baseDirectory}' with token and options '${options.join(' ')}'`);
+    core.debug(`Executing 'git clone' for repository '${ghRepository}' with ${token ? 'token' : 'SSH key'} and options '${options.join(' ')}'`);
+
+    if (!token) {
+        await setupSshKey();
+    }
 
     const remote = getRepoRemoteUrl(token, ghRepository);
     let args = ['clone', remote, baseDirectory];
@@ -152,6 +201,7 @@ export async function clone(
 
     return cmd(additionalGitOptions, ...args);
 }
+
 export async function checkout(
     ghRef: string,
     additionalGitOptions: string[] = [],


### PR DESCRIPTION
I'd like to be able to push to other repositories in my org using our SSH deploy key instead of a personal access token or a Github application token. Currently, github-action-benchmark only supports `github-token` for such scenarios. This PR adds a `ssh-key` as an alternative.

The code takes the `ssh-key` setting, puts it into `.ssh` in the Github runner, and updates the core git SSH command to use the key. All of the git-related commands then call the `setupSshKey` method prior to running.

Fixes #133