### PR TITLE
Add summary even when failure threshold is surpassed

### DIFF
--- a/src/write.ts
+++ b/src/write.ts
@@ -541,8 +541,8 @@ export async function writeBenchmark(bench: Benchmark, config: Config) {
         core.debug('Alert check was skipped because previous benchmark result was not found');
     } else {
         await handleComment(name, bench, prevBench, config);
-        await handleAlert(name, bench, prevBench, config);
         await handleSummary(name, bench, prevBench, config);
+        await handleAlert(name, bench, prevBench, config);
     }
 }
 


### PR DESCRIPTION
Alerts are currently generated by throwing an exception. This means that all code that comes after that exception is skipped, including generating the Action summary.

We can easily fix this, by generating the summary first.

Longer term, we might want to reconsider the code style here. An exception should model something exceptional happening in our code. Seeing bad benchmark numbers is not exceptional. It's what this tool is supposed to handle.

Closes https://github.com/benchmark-action/github-action-benchmark/issues/254