### PR TITLE
fix: use merge commit timestamp for PR benchmark entries

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { promises as fs } from 'fs';
 import * as github from '@actions/github';
+import { cmd } from './git';
 import { Config, ToolType } from './config';
 import { z } from 'zod';
 
@@ -239,21 +240,24 @@ function getHumanReadableUnitValue(seconds: number): [number, string] {
     }
 }
 
-function getCommitFromPullRequestPayload(pr: PullRequest): Commit {
-    // On pull_request hook, head_commit is not available
+async function getCommitFromPullRequestPayload(pr: PullRequest): Promise<Commit> {
+    // On pull_request hook, head_commit is not available.
+    // HEAD is the merge commit GitHub creates for the PR, always accessible even with shallow clones.
+    // Its timestamp is within seconds of the actual commit time.
     const id: string = pr.head.sha;
     const username: string = pr.head.user.login;
     const user = {
         name: username, // XXX: Fallback, not correct
         username,
     };
+    const timestamp = (await cmd([], 'log', '-1', '--format=%aI', 'HEAD')).trim();
 
     return {
         author: user,
         committer: user,
         id,
         message: pr.title,
-        timestamp: pr.head.repo.updated_at,
+        timestamp,
         url: `${pr.html_url}/commits/${id}`,
     };
 }
@@ -299,7 +303,7 @@ async function getCommit(githubToken?: string, ref?: string): Promise<Commit> {
     const pr = github.context.payload.pull_request;
 
     if (pr) {
-        return getCommitFromPullRequestPayload(pr);
+        return await getCommitFromPullRequestPayload(pr);
     }
 
     if (!githubToken) {

--- a/test/extract.spec.ts
+++ b/test/extract.spec.ts
@@ -37,6 +37,10 @@ const dummyGitHubContext = {
     ref: 'abcd1234',
 };
 
+jest.mock('../src/git', () => ({
+    cmd: jest.fn().mockResolvedValue('2024-01-15T10:30:00+00:00\n'),
+}));
+
 jest.mock('@actions/github', () => ({
     get context() {
         return dummyGitHubContext;
@@ -218,9 +222,7 @@ describe('extractResult()', function () {
                     user: {
                         login: 'user',
                     },
-                    repo: {
-                        updated_at: 'repo updated at timestamp',
-                    },
+                    repo: {},
                 },
             },
         };
@@ -238,7 +240,7 @@ describe('extractResult()', function () {
         A.deepEqual(commit.committer, expectedUser);
         A.equal(commit.id, 'abcdef0123456789');
         A.equal(commit.message, 'this is title');
-        A.equal(commit.timestamp, 'repo updated at timestamp');
+        A.equal(commit.timestamp, '2024-01-15T10:30:00+00:00');
         A.equal(commit.url, 'https://github.com/dummy/repo/pull/1/commits/abcdef0123456789');
     });
 


### PR DESCRIPTION
## Problem

`getCommitFromPullRequestPayload` was using `pr.head.repo.updated_at` as the commit timestamp. This field reflects when the repository's metadata was last updated — for forks, that's typically the last time the fork was synced with upstream, which can be months in the past. The result is a wildly incorrect timestamp in the benchmark chart tooltip.

## Solution analysis

We considered three approaches:

**1. GitHub API** (`getCommitFromGitHubAPIRequest`) — accurate, but requires `github-token` to be provided. The issue reporter suggested making the token always required for PR contexts, but we wanted to avoid that.

**2. `git log -1 --format=%aI <pr.head.sha>`** — accurate (real commit author date), no token needed. However, `actions/checkout` defaults to `fetch-depth: 1` (shallow clone), which fetches the synthetic merge commit (`refs/pull/N/merge`) but not its parents. `pr.head.sha` is a parent of the merge commit and is not available as a git object in a shallow clone, so this fails in the common case.

**3. `git log -1 --format=%aI HEAD`** (chosen) — reads the timestamp from the merge commit GitHub creates for the PR. This commit is always `HEAD` after `actions/checkout`, accessible even with `fetch-depth: 1`. GitHub sets the merge commit's timestamp at creation time, which is within seconds of the actual push. Verified with a real PR: merge commit was 3 seconds newer than the PR head commit.

## Trade-off

The timestamp is the merge commit time, not the developer's commit author time. The difference is consistently < 30 seconds in practice — acceptable for a chart tooltip, and vastly better than the current bug which can be months off for fork PRs.

No token required. No fork detection needed. No fallback complexity.

Fixes #327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved commit timestamp accuracy by sourcing directly from git history instead of external data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->