### PR TITLE
chore: add tracker config and ignore *.local files

### DIFF
--- a/.claude/tracker.yaml
+++ b/.claude/tracker.yaml
@@ -1,0 +1,5 @@
+tracker:
+  type: github
+  github:
+    repo: benchmark-action/github-action-benchmark
+    in_review_label: in-review

--- a/.claude/tracker.yaml
+++ b/.claude/tracker.yaml
@@ -1,3 +1,17 @@
+# Tracker config for Claude Code skills.
+#
+# Tells Claude skills (plan-feature, create-pr, resolve-pr-comments, etc.)
+# which issue tracker this repo uses, so they can fetch tickets, link them
+# in PRs, and transition statuses without per-invocation prompts.
+#
+# Resolution order: this file first, then ~/.claude/tracker.yaml as a
+# fallback. Schema and supported backends (jira, linear, github, clickup)
+# are documented at:
+#   https://github.com/ktrz/skills/blob/main/_shared/references/tracker.md
+#
+# Safe to commit: contains no secrets — only the public repo slug and the
+# label name used to mark issues as "in review".
+
 tracker:
   type: github
   github:

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 target/
 jmh-result.json
 .env
+*.local
+*.local.*


### PR DESCRIPTION
### Description

- Add `.claude/tracker.yaml` declaring this repo as GitHub-tracker so Claude skills (plan-feature, create-pr, etc.) can dispatch correctly without per-invocation configuration. Schema documented in [the skills' tracker reference](https://github.com/ktrz/skills/blob/main/_shared/references/tracker.md).
- Add `*.local` and `*.local.*` patterns to `.gitignore` so personal overrides like `.claude/settings.local.json` stay out of git.

### Test scenario

- [ ] `git check-ignore -v .claude/settings.local.json` reports `.gitignore:*.local.*` as the matching rule.
- [ ] `cat .claude/tracker.yaml` shows the GitHub-typed config pointing at this repo.
- [ ] No code paths affected — config-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added tracker configuration for GitHub integration.
  * Updated `.gitignore` to exclude local configuration files (*.local and *.local.*).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->