### PR TITLE
fix(ci): eliminate race in validate script via single git history source

### DIFF
--- a/.github/workflows/ci-results-repo.yml
+++ b/.github/workflows/ci-results-repo.yml
@@ -25,15 +25,6 @@ jobs:
       - name: Run benchmark
         run: cd examples/benchmarkdotnet && dotnet run --exporters json --filter '*'
 
-      - uses: actions/checkout@v4
-        with:
-          repository: benchmark-action/github-action-benchmark-results
-          ref: 'gh-pages'
-          path: 'dist/other-repo'
-      - name: Save previous data.js
-        run: |
-          cp ./dist/other-repo/dev/bench/data.js before_data.js
-
       - name: Store benchmark result
         uses: ./
         with:
@@ -43,7 +34,7 @@ jobs:
           fail-on-alert: true
           gh-repository: 'github.com/benchmark-action/github-action-benchmark-results'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Benchmark.Net Benchmark' './benchmark-data-repository'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Benchmark.Net Benchmark' './benchmark-data-repository'
 
   benchmarkjs:
     name: Run JavaScript benchmark example - github.com/benchmark-action/github-action-benchmark-results
@@ -59,15 +50,6 @@ jobs:
       - name: Run benchmark
         run: cd examples/benchmarkjs && npm install && node bench.js | tee output.txt
 
-      - uses: actions/checkout@v4
-        with:
-          repository: benchmark-action/github-action-benchmark-results
-          ref: 'gh-pages'
-          path: 'dist/other-repo'
-      - name: Save previous data.js
-        run: |
-          cp ./dist/other-repo/dev/bench/data.js before_data.js
-
       - name: Store benchmark result
         uses: ./
         with:
@@ -77,7 +59,7 @@ jobs:
           fail-on-alert: true
           gh-repository: 'github.com/benchmark-action/github-action-benchmark-results'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Benchmark.js Benchmark' './benchmark-data-repository'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Benchmark.js Benchmark' './benchmark-data-repository'
 
   catch2-v2-framework:
     name: Run Catch2 C++ Benchmark Framework example (v2.x) - github.com/benchmark-action/github-action-benchmark-results
@@ -98,15 +80,6 @@ jobs:
           cmake --build . --config Release
           ./Catch2_bench > ../benchmark_result.txt
 
-      - uses: actions/checkout@v4
-        with:
-          repository: benchmark-action/github-action-benchmark-results
-          ref: 'gh-pages'
-          path: 'dist/other-repo'
-      - name: Save previous data.js
-        run: |
-          cp ./dist/other-repo/dev/bench/data.js before_data.js
-
       - name: Store benchmark result
         uses: ./
         with:
@@ -116,7 +89,7 @@ jobs:
           fail-on-alert: true
           gh-repository: 'github.com/benchmark-action/github-action-benchmark-results'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Catch2 Benchmark' './benchmark-data-repository'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Catch2 Benchmark' './benchmark-data-repository'
 
   catch2-v3-framework:
     name: Run Catch2 C++ Benchmark Framework example (v3.x) - github.com/benchmark-action/github-action-benchmark-results
@@ -137,15 +110,6 @@ jobs:
           cmake --build . --config Release
           ./Catch2_bench > ../benchmark_result.txt
 
-      - uses: actions/checkout@v4
-        with:
-          repository: benchmark-action/github-action-benchmark-results
-          ref: 'gh-pages'
-          path: 'dist/other-repo'
-      - name: Save previous data.js
-        run: |
-          cp ./dist/other-repo/dev/bench/data.js before_data.js
-
       - name: Store benchmark result
         uses: ./
         with:
@@ -155,7 +119,7 @@ jobs:
           fail-on-alert: true
           gh-repository: 'github.com/benchmark-action/github-action-benchmark-results'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Catch2 Benchmark (v3)' './benchmark-data-repository'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Catch2 Benchmark (v3)' './benchmark-data-repository'
 
   cpp-framework:
     name: Run Google C++ Benchmark Framework example - github.com/benchmark-action/github-action-benchmark-results
@@ -178,15 +142,6 @@ jobs:
           cd examples/cpp
           make json
 
-      - uses: actions/checkout@v4
-        with:
-          repository: benchmark-action/github-action-benchmark-results
-          ref: 'gh-pages'
-          path: 'dist/other-repo'
-      - name: Save previous data.js
-        run: |
-          cp ./dist/other-repo/dev/bench/data.js before_data.js
-
       - name: Store benchmark result
         uses: ./
         with:
@@ -196,7 +151,7 @@ jobs:
           fail-on-alert: true
           gh-repository: 'github.com/benchmark-action/github-action-benchmark-results'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'C++ Benchmark' './benchmark-data-repository'
+      - run: npx tsx scripts/ci_validate_modification.ts 'C++ Benchmark' './benchmark-data-repository'
 
   go:
     name: Run Go benchmark example - github.com/benchmark-action/github-action-benchmark-results
@@ -215,15 +170,6 @@ jobs:
       - name: Run benchmark
         run: cd examples/go && go test -bench 'BenchmarkFib' | tee output.txt
 
-      - uses: actions/checkout@v4
-        with:
-          repository: benchmark-action/github-action-benchmark-results
-          ref: 'gh-pages'
-          path: 'dist/other-repo'
-      - name: Save previous data.js
-        run: |
-          cp ./dist/other-repo/dev/bench/data.js before_data.js
-
       - name: Store benchmark result
         uses: ./
         with:
@@ -233,7 +179,7 @@ jobs:
           fail-on-alert: true
           gh-repository: 'github.com/benchmark-action/github-action-benchmark-results'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Go Benchmark' './benchmark-data-repository'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Go Benchmark' './benchmark-data-repository'
 
   java-jmh:
     name: Run JMH Java Benchmark Framework example
@@ -255,14 +201,6 @@ jobs:
           cd examples/java
           mvn clean verify
           java -jar target/benchmarks.jar -wi 1 -i 3 -f 1 -rf json
-      - uses: actions/checkout@v4
-        with:
-          repository: benchmark-action/github-action-benchmark-results
-          ref: 'gh-pages'
-          path: 'dist/other-repo'
-      - name: Save previous data.js
-        run: |
-          cp ./dist/other-repo/dev/bench/data.js before_data.js
       - name: Store benchmark result
         uses: ./
         with:
@@ -272,7 +210,7 @@ jobs:
           fail-on-alert: true
           gh-repository: 'github.com/benchmark-action/github-action-benchmark-results'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'JMH Benchmark' './benchmark-data-repository'
+      - run: npx tsx scripts/ci_validate_modification.ts 'JMH Benchmark' './benchmark-data-repository'
 
   julia-benchmark:
     name: Run Julia benchmark example - github.com/benchmark-action/github-action-benchmark-results
@@ -297,15 +235,6 @@ jobs:
             Pkg.instantiate();
             include("fib.jl")'
 
-      - uses: actions/checkout@v4
-        with:
-          repository: benchmark-action/github-action-benchmark-results
-          ref: 'gh-pages'
-          path: 'dist/other-repo'
-      - name: Save previous data.js
-        run: |
-          cp ./dist/other-repo/dev/bench/data.js before_data.js
-
       - name: Store benchmark result
         uses: ./
         with:
@@ -315,7 +244,7 @@ jobs:
           fail-on-alert: true
           gh-repository: 'github.com/benchmark-action/github-action-benchmark-results'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Julia benchmark' './benchmark-data-repository'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Julia benchmark' './benchmark-data-repository'
 
   pytest-benchmark:
     name: Run Pytest benchmark example - github.com/benchmark-action/github-action-benchmark-results
@@ -337,15 +266,6 @@ jobs:
           pip install -r requirements.txt
           pytest bench.py --benchmark-json output.json
 
-      - uses: actions/checkout@v4
-        with:
-          repository: benchmark-action/github-action-benchmark-results
-          ref: 'gh-pages'
-          path: 'dist/other-repo'
-      - name: Save previous data.js
-        run: |
-          cp ./dist/other-repo/dev/bench/data.js before_data.js
-
       - name: Store benchmark result
         uses: ./
         with:
@@ -355,7 +275,7 @@ jobs:
           fail-on-alert: true
           gh-repository: 'github.com/benchmark-action/github-action-benchmark-results'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Python Benchmark with pytest-benchmark' './benchmark-data-repository'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Python Benchmark with pytest-benchmark' './benchmark-data-repository'
 
   rust:
     name: Run Rust benchmark example - github.com/benchmark-action/github-action-benchmark-results
@@ -372,15 +292,6 @@ jobs:
       - name: Run benchmark
         run: cd examples/rust && cargo +nightly bench | tee output.txt
 
-      - uses: actions/checkout@v4
-        with:
-          repository: benchmark-action/github-action-benchmark-results
-          ref: 'gh-pages'
-          path: 'dist/other-repo'
-      - name: Save previous data.js
-        run: |
-          cp ./dist/other-repo/dev/bench/data.js before_data.js
-
       - name: Store benchmark result
         uses: ./
         with:
@@ -390,7 +301,7 @@ jobs:
           fail-on-alert: true
           gh-repository: 'github.com/benchmark-action/github-action-benchmark-results'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Rust Benchmark' './benchmark-data-repository'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Rust Benchmark' './benchmark-data-repository'
 
   rust-criterion-rs-framework:
     name: Run Criterion.rs benchmark example - github.com/benchmark-action/github-action-benchmark-results
@@ -407,15 +318,6 @@ jobs:
       - name: Run benchmark
         run: cd examples/criterion-rs && cargo +nightly bench -- --output-format bencher | tee output.txt
 
-      - uses: actions/checkout@v4
-        with:
-          repository: benchmark-action/github-action-benchmark-results
-          ref: 'gh-pages'
-          path: 'dist/other-repo'
-      - name: Save previous data.js
-        run: |
-          cp ./dist/other-repo/dev/bench/data.js before_data.js
-
       - name: Store benchmark result
         uses: ./
         with:
@@ -425,7 +327,7 @@ jobs:
           fail-on-alert: true
           gh-repository: 'github.com/benchmark-action/github-action-benchmark-results'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Criterion.rs Benchmark' './benchmark-data-repository'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Criterion.rs Benchmark' './benchmark-data-repository'
 
   only-alert-with-cache:
     name: Run alert check with actions/cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,6 @@ jobs:
       - run: npm run build
       - name: Run benchmark
         run: cd examples/benchmarkdotnet && dotnet run --exporters json --filter '*'
-      - name: Save previous data.js
-        run: |
-          git fetch origin gh-pages
-          git checkout gh-pages
-          cp ./dev/bench/data.js before_data.js
-          git checkout -
       - name: Store benchmark result
         uses: ./
         with:
@@ -41,7 +35,7 @@ jobs:
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Benchmark.Net Benchmark'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Benchmark.Net Benchmark'
 
   benchmarkjs:
     name: Run JavaScript benchmark example
@@ -56,12 +50,6 @@ jobs:
       - run: npm run build
       - name: Run benchmark
         run: cd examples/benchmarkjs && npm install && node bench.js | tee output.txt
-      - name: Save previous data.js
-        run: |
-          git fetch origin gh-pages
-          git checkout gh-pages
-          cp ./dev/bench/data.js before_data.js
-          git checkout -
       - name: Store benchmark result
         uses: ./
         with:
@@ -73,7 +61,7 @@ jobs:
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Benchmark.js Benchmark'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Benchmark.js Benchmark'
 
   catch2-v2-framework:
     name: Run Catch2 C++ Benchmark Framework example (v2.x)
@@ -93,12 +81,6 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=Release ..
           cmake --build . --config Release
           ./Catch2_bench > ../benchmark_result.txt
-      - name: Save previous data.js
-        run: |
-          git fetch origin gh-pages
-          git checkout gh-pages
-          cp ./dev/bench/data.js before_data.js
-          git checkout -
       - name: Store benchmark result
         uses: ./
         with:
@@ -110,7 +92,7 @@ jobs:
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Catch2 Benchmark'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Catch2 Benchmark'
 
   catch2-v3-framework:
     name: Run Catch2 C++ Benchmark Framework example (v3.x)
@@ -130,12 +112,6 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=Release ..
           cmake --build . --config Release
           ./Catch2_bench > ../benchmark_result.txt
-      - name: Save previous data.js
-        run: |
-          git fetch origin gh-pages
-          git checkout gh-pages
-          cp ./dev/bench/data.js before_data.js
-          git checkout -
       - name: Store benchmark result
         uses: ./
         with:
@@ -147,7 +123,7 @@ jobs:
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Catch2 Benchmark (v3)'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Catch2 Benchmark (v3)'
 
   cpp-framework:
     name: Run Google C++ Benchmark Framework example
@@ -169,12 +145,6 @@ jobs:
         run: |
           cd examples/cpp
           make json
-      - name: Save previous data.js
-        run: |
-          git fetch origin gh-pages
-          git checkout gh-pages
-          cp ./dev/bench/data.js before_data.js
-          git checkout -
       - name: Store benchmark result
         uses: ./
         with:
@@ -186,7 +156,7 @@ jobs:
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'C++ Benchmark'
+      - run: npx tsx scripts/ci_validate_modification.ts 'C++ Benchmark'
 
   go:
     name: Run Go benchmark example
@@ -204,12 +174,6 @@ jobs:
       - run: npm run build
       - name: Run benchmark
         run: cd examples/go && go test -bench 'BenchmarkFib' | tee output.txt
-      - name: Save previous data.js
-        run: |
-          git fetch origin gh-pages
-          git checkout gh-pages
-          cp ./dev/bench/data.js before_data.js
-          git checkout -
       - name: Store benchmark result
         uses: ./
         with:
@@ -221,7 +185,7 @@ jobs:
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Go Benchmark'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Go Benchmark'
 
   java-jmh:
     name: Run JMH Java Benchmark Framework example
@@ -243,12 +207,6 @@ jobs:
           cd examples/java
           mvn clean verify
           java -jar target/benchmarks.jar -wi 1 -i 3 -f 1 -rf json
-      - name: Save previous data.js
-        run: |
-          git fetch origin gh-pages
-          git checkout gh-pages
-          cp ./dev/bench/data.js before_data.js
-          git checkout -
       - name: Store benchmark result
         uses: ./
         with:
@@ -260,7 +218,7 @@ jobs:
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'JMH Benchmark'
+      - run: npx tsx scripts/ci_validate_modification.ts 'JMH Benchmark'
 
   julia-benchmark:
     name: Run Julia benchmark example
@@ -284,12 +242,6 @@ jobs:
             using Pkg;
             Pkg.instantiate();
             include("fib.jl")'
-      - name: Save previous data.js
-        run: |
-          git fetch origin gh-pages
-          git checkout gh-pages
-          cp ./dev/bench/data.js before_data.js
-          git checkout -
       - name: Store benchmark result
         uses: ./
         with:
@@ -301,7 +253,7 @@ jobs:
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Julia benchmark'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Julia benchmark'
 
   pytest-benchmark:
     name: Run Pytest benchmark example
@@ -322,12 +274,6 @@ jobs:
           cd examples/pytest
           pip install -r requirements.txt
           pytest bench.py --benchmark-json output.json
-      - name: Save previous data.js
-        run: |
-          git fetch origin gh-pages
-          git checkout gh-pages
-          cp ./dev/bench/data.js before_data.js
-          git checkout -
       - name: Store benchmark result
         uses: ./
         with:
@@ -339,7 +285,7 @@ jobs:
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Python Benchmark with pytest-benchmark'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Python Benchmark with pytest-benchmark'
 
   rust:
     name: Run Rust benchmark example
@@ -355,12 +301,6 @@ jobs:
       - run: rustup toolchain update nightly && rustup default nightly
       - name: Run benchmark
         run: cd examples/rust && cargo +nightly bench | tee output.txt
-      - name: Save previous data.js
-        run: |
-          git fetch origin gh-pages
-          git checkout gh-pages
-          cp ./dev/bench/data.js before_data.js
-          git checkout -
       - name: Store benchmark result
         uses: ./
         with:
@@ -371,7 +311,7 @@ jobs:
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Rust Benchmark'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Rust Benchmark'
 
   rust-criterion-rs-framework:
     name: Run Criterion.rs benchmark example
@@ -387,12 +327,6 @@ jobs:
       - run: rustup toolchain update nightly && rustup default nightly
       - name: Run benchmark
         run: cd examples/criterion-rs && cargo +nightly bench -- --output-format bencher | tee output.txt
-      - name: Save previous data.js
-        run: |
-          git fetch origin gh-pages
-          git checkout gh-pages
-          cp ./dev/bench/data.js before_data.js
-          git checkout -
       - name: Store benchmark result
         uses: ./
         with:
@@ -403,7 +337,7 @@ jobs:
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
-      - run: npx tsx scripts/ci_validate_modification.ts before_data.js 'Criterion.rs Benchmark'
+      - run: npx tsx scripts/ci_validate_modification.ts 'Criterion.rs Benchmark'
 
   only-alert-with-cache:
     name: Run alert check with actions/cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           dotnet-version: '6.0.101'  # SDK Version to use. keep in line with examples/benchmarkdotnet/global.json
       - run: npm ci
       - run: npm run build
+      - name: Fetch gh-pages branch
+        run: git fetch origin gh-pages:gh-pages
       - name: Run benchmark
         run: cd examples/benchmarkdotnet && dotnet run --exporters json --filter '*'
       - name: Store benchmark result
@@ -48,6 +50,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
+      - name: Fetch gh-pages branch
+        run: git fetch origin gh-pages:gh-pages
       - name: Run benchmark
         run: cd examples/benchmarkjs && npm install && node bench.js | tee output.txt
       - name: Store benchmark result
@@ -74,6 +78,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
+      - name: Fetch gh-pages branch
+        run: git fetch origin gh-pages:gh-pages
       - name: Run benchmark
         run: |
           cd examples/catch2_v2
@@ -105,6 +111,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
+      - name: Fetch gh-pages branch
+        run: git fetch origin gh-pages:gh-pages
       - name: Run benchmark
         run: |
           cd examples/catch2
@@ -136,6 +144,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
+      - name: Fetch gh-pages branch
+        run: git fetch origin gh-pages:gh-pages
       - name: Cache Benchmark library
         uses: actions/cache@v4
         with:
@@ -172,6 +182,8 @@ jobs:
           go-version: "stable"
       - run: npm ci
       - run: npm run build
+      - name: Fetch gh-pages branch
+        run: git fetch origin gh-pages:gh-pages
       - name: Run benchmark
         run: cd examples/go && go test -bench 'BenchmarkFib' | tee output.txt
       - name: Store benchmark result
@@ -202,6 +214,8 @@ jobs:
           java-version: '11'
       - run: npm ci
       - run: npm run build
+      - name: Fetch gh-pages branch
+        run: git fetch origin gh-pages:gh-pages
       - name: Run benchmark
         run: |
           cd examples/java
@@ -231,6 +245,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
+      - name: Fetch gh-pages branch
+        run: git fetch origin gh-pages:gh-pages
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
@@ -269,6 +285,8 @@ jobs:
           python-version: 3.9
       - run: npm ci
       - run: npm run build
+      - name: Fetch gh-pages branch
+        run: git fetch origin gh-pages:gh-pages
       - name: Run benchmark
         run: |
           cd examples/pytest

--- a/scripts/ci_validate_modification.ts
+++ b/scripts/ci_validate_modification.ts
@@ -6,13 +6,10 @@ import { VALID_TOOLS } from '../src/config';
 import { Benchmark } from '../src/extract';
 import { diff, Diff, DiffArray, DiffEdit, DiffNew } from 'deep-diff';
 import { getServerUrl } from '../src/git';
-import assert from 'assert';
 import deepEq = require('deep-equal');
 
 function help(): never {
-    throw new Error(
-        'Usage: node ci_validate_modification.js before_data.js "benchmark name" [benchmark-data-repository-directory]',
-    );
+    throw new Error('Usage: node ci_validate_modification.js "benchmark name" [benchmark-data-repository-directory]');
 }
 
 async function exec(cmd: string): Promise<string> {
@@ -28,8 +25,8 @@ async function exec(cmd: string): Promise<string> {
     });
 }
 
-async function readDataJson(file: string): Promise<DataJson> {
-    const content = await fs.readFile(file, 'utf8');
+async function readDataJsonFromGit(gitParams: string, ref: string): Promise<DataJson> {
+    const content = await exec(`git ${gitParams} show ${ref}:dev/bench/data.js`);
     return JSON.parse(content.slice(SCRIPT_PREFIX.length));
 }
 
@@ -207,7 +204,7 @@ function validateDiff(beforeJson: DataJson, afterJson: DataJson, expectedBenchNa
 async function main() {
     console.log('Start validating modifications by action with args', process.argv);
 
-    if (process.argv.length !== 4 && process.argv.length !== 5) {
+    if (process.argv.length !== 3 && process.argv.length !== 4) {
         help();
     }
 
@@ -221,19 +218,14 @@ async function main() {
         throw new Error('This script must be run at root directory of repository');
     }
 
-    const beforeDataJs = path.resolve(process.argv[2]);
-    const expectedBenchName = process.argv[3];
-    const benchmarkDataDirectory = process.argv[4];
+    const expectedBenchName = process.argv[2];
+    const benchmarkDataDirectory = process.argv[3];
 
     const additionalGitParams = benchmarkDataDirectory
         ? `--work-tree=${benchmarkDataDirectory} --git-dir=${benchmarkDataDirectory}/.git`
         : '';
 
     console.log('Validating modifications by action');
-    console.log(`  data.js before action: ${beforeDataJs}`);
-
-    console.log('Reading data.js before action as JSON');
-    const beforeJson = await readDataJson(beforeDataJs);
 
     console.log('Validating current branch');
     const branch = await exec(`git ${additionalGitParams} rev-parse --abbrev-ref HEAD`);
@@ -264,18 +256,12 @@ async function main() {
         throw new Error(`Unexpected auto commit message in log '${latestCommitLog}'`);
     }
 
-    const dataResults = await Promise.allSettled([
-        readDataJson('benchmark-data-repository/dev/bench/data.js'),
-        readDataJson('dev/bench/data.js'),
-    ]);
+    console.log('Reading data.js before action as JSON (HEAD~1)');
+    const beforeJson = await readDataJsonFromGit(additionalGitParams, 'HEAD~1');
 
-    const jsonResults = dataResults
-        .filter((res): res is PromiseFulfilledResult<DataJson> => res.status === 'fulfilled')
-        .map((res) => res.value);
+    console.log('Reading data.js after action as JSON (HEAD)');
+    const afterJson = await readDataJsonFromGit(additionalGitParams, 'HEAD');
 
-    assert(jsonResults.length > 0 && jsonResults.length <= 2, 'Maximum 2 data.js files should be present in the repo');
-
-    const afterJson = jsonResults[0];
     await exec(`git ${additionalGitParams} checkout -`);
 
     console.log('Validating data.js both before/after action');

--- a/scripts/ci_validate_modification.ts
+++ b/scripts/ci_validate_modification.ts
@@ -12,22 +12,47 @@ function help(): never {
     throw new Error('Usage: node ci_validate_modification.js "benchmark name" [benchmark-data-repository-directory]');
 }
 
-async function exec(cmd: string): Promise<string> {
+interface GitContext {
+    benchmarkDataDirectory?: string;
+}
+
+function gitArgsFor(ctx: GitContext): string[] {
+    if (!ctx.benchmarkDataDirectory) {
+        return [];
+    }
+    return [`--work-tree=${ctx.benchmarkDataDirectory}`, `--git-dir=${ctx.benchmarkDataDirectory}/.git`];
+}
+
+function execGit(ctx: GitContext, ...args: string[]): Promise<string> {
+    const argv = [...gitArgsFor(ctx), ...args];
+    const cmd = `git ${argv.join(' ')}`;
     console.log(`+ ${cmd}`);
     return new Promise((resolve, reject) => {
-        cp.exec(cmd, (err, stdout, stderr) => {
+        cp.execFile('git', argv, { maxBuffer: 100 * 1024 * 1024 }, (err, stdout, stderr) => {
             if (err) {
                 reject(new Error(`Exec '${cmd}' failed with error ${err.message}. Stderr: '${stderr}'`));
                 return;
             }
+            if (stderr) console.warn(`stderr from '${cmd}': ${stderr}`);
             resolve(stdout);
         });
     });
 }
 
-async function readDataJsonFromGit(gitParams: string, ref: string): Promise<DataJson> {
-    const content = await exec(`git ${gitParams} show ${ref}:dev/bench/data.js`);
-    return JSON.parse(content.slice(SCRIPT_PREFIX.length));
+async function tryReadBenchDataJsAtRef(ctx: GitContext, ref: string): Promise<DataJson | null> {
+    let content: string;
+    try {
+        content = await execGit(ctx, 'show', `${ref}:dev/bench/data.js`);
+    } catch (err) {
+        console.log(`No data.js at ${ref} (first run / new tool): ${err}`);
+        return null;
+    }
+    if (!content.startsWith(SCRIPT_PREFIX)) {
+        throw new Error(
+            `data.js at ${ref} does not begin with expected SCRIPT_PREFIX. First 64 chars: ${content.slice(0, 64)}`,
+        );
+    }
+    return JSON.parse(content.slice(SCRIPT_PREFIX.length)) as DataJson;
 }
 
 function validateDataJson(data: DataJson) {
@@ -219,59 +244,63 @@ async function main() {
     }
 
     const expectedBenchName = process.argv[2];
-    const benchmarkDataDirectory = process.argv[3];
-
-    const additionalGitParams = benchmarkDataDirectory
-        ? `--work-tree=${benchmarkDataDirectory} --git-dir=${benchmarkDataDirectory}/.git`
-        : '';
+    const ctx: GitContext = { benchmarkDataDirectory: process.argv[3] };
 
     console.log('Validating modifications by action');
 
     console.log('Validating current branch');
-    const branch = await exec(`git ${additionalGitParams} rev-parse --abbrev-ref HEAD`);
+    const branch = (await execGit(ctx, 'rev-parse', '--abbrev-ref', 'HEAD')).trim();
     if (branch === 'gh-pages') {
         throw new Error(`Current branch is still on '${branch}'`);
     }
 
     console.log('Retrieving data.js after action');
-    await exec(`git ${additionalGitParams} checkout gh-pages`);
-    const latestCommitLog = await exec(`git ${additionalGitParams} log -n 1`);
+    await execGit(ctx, 'checkout', 'gh-pages');
+    try {
+        const latestCommitLog = await execGit(ctx, 'log', '-n', '1');
 
-    console.log('Validating auto commit');
-    const commitLogLines = latestCommitLog.split('\n');
+        console.log('Validating auto commit');
+        const commitLogLines = latestCommitLog.split('\n');
 
-    const commitAuthorLine = commitLogLines[1];
-    if (!commitAuthorLine.startsWith('Author: github-action-benchmark')) {
-        throw new Error(`Unexpected auto commit author in log '${latestCommitLog}'`);
+        const commitAuthorLine = commitLogLines[1];
+        if (!commitAuthorLine.startsWith('Author: github-action-benchmark')) {
+            throw new Error(`Unexpected auto commit author in log '${latestCommitLog}'`);
+        }
+
+        const commitMessageLine = commitLogLines[4];
+        const reCommitMessage = new RegExp(
+            `add ${expectedBenchName.replace(
+                /[.*+?^=!:${}()|[\]/\\]/g,
+                '\\$&',
+            )} \\([^)]+\\) benchmark result for [0-9a-f]+$`,
+        );
+        if (!reCommitMessage.test(commitMessageLine)) {
+            throw new Error(`Unexpected auto commit message in log '${latestCommitLog}'`);
+        }
+
+        console.log('Reading data.js after action as JSON (HEAD)');
+        const afterJson = await tryReadBenchDataJsAtRef(ctx, 'HEAD');
+        if (!afterJson) {
+            throw new Error('data.js missing at HEAD on gh-pages branch after action commit');
+        }
+
+        console.log('Reading data.js before action as JSON (HEAD~1)');
+        const beforeJson =
+            (await tryReadBenchDataJsAtRef(ctx, 'HEAD~1')) ??
+            ({ lastUpdate: 0, repoUrl: afterJson.repoUrl, entries: {} } as DataJson);
+
+        console.log('Validating data.js both before/after action');
+        validateDataJson(beforeJson);
+        validateDataJson(afterJson);
+
+        validateDiff(beforeJson, afterJson, expectedBenchName);
+    } finally {
+        await execGit(ctx, 'checkout', '-');
     }
-
-    const commitMessageLine = commitLogLines[4];
-    const reCommitMessage = new RegExp(
-        `add ${expectedBenchName.replace(
-            /[.*+?^=!:${}()|[\]/\\]/g,
-            '\\$&',
-        )} \\([^)]+\\) benchmark result for [0-9a-f]+$`,
-    );
-    if (!reCommitMessage.test(commitMessageLine)) {
-        throw new Error(`Unexpected auto commit message in log '${latestCommitLog}'`);
-    }
-
-    console.log('Reading data.js before action as JSON (HEAD~1)');
-    const beforeJson = await readDataJsonFromGit(additionalGitParams, 'HEAD~1');
-
-    console.log('Reading data.js after action as JSON (HEAD)');
-    const afterJson = await readDataJsonFromGit(additionalGitParams, 'HEAD');
-
-    await exec(`git ${additionalGitParams} checkout -`);
-
-    console.log('Validating data.js both before/after action');
-    validateDataJson(beforeJson);
-    validateDataJson(afterJson);
-
-    validateDiff(beforeJson, afterJson, expectedBenchName);
 }
 
 main().catch((err) => {
-    console.error(err);
+    const prefix = /Exec 'git\b/.test(err.message) ? '[git-error]' : '[validation-error]';
+    console.error(prefix, err);
     process.exit(110);
 });

--- a/scripts/ci_validate_modification.ts
+++ b/scripts/ci_validate_modification.ts
@@ -250,7 +250,7 @@ async function main() {
 
     console.log('Validating current branch');
     const branch = (await execGit(ctx, 'rev-parse', '--abbrev-ref', 'HEAD')).trim();
-    if (branch === 'gh-pages') {
+    if (!ctx.benchmarkDataDirectory && branch === 'gh-pages') {
         throw new Error(`Current branch is still on '${branch}'`);
     }
 


### PR DESCRIPTION
### Description

- Validate script (`scripts/ci_validate_modification.ts`) was failing on master with `Error: Number of diffs are incorrect. Exact 2 diffs are expected` ([example failing run](https://github.com/benchmark-action/github-action-benchmark/actions/runs/25428125480/job/74586926151)).
- Root cause: race between two clones of the results repo. `before_data.js` was captured from one `actions/checkout` snapshot taken at T1; `after` came from a second clone the action makes internally at T4. Parallel workflows pushing to `gh-pages` between T1 and T4 introduced extra diffs, exceeding the strict `=== 2` assertion.
- Fix: derive `before` and `after` from the **same** clone using `git show HEAD~1:dev/bench/data.js` (parent of action's auto-commit) and `git show HEAD:dev/bench/data.js`. Race window collapses to zero.
- Drops the now-unnecessary `Save previous data.js` workflow step and `dist/other-repo` checkout from both `ci.yml` (11 jobs) and `ci-results-repo.yml` (11 jobs), plus the `before_data.js` CLI arg.

### Test scenario

- [ ] Watch this PR's `CI` and `CI - separate results repo` workflow runs; all benchmark jobs pass with the new validate command shape `npx tsx scripts/ci_validate_modification.ts '<bench name>' [<dir>]`
- [ ] After merge, watch the next 10–20 master pushes for the absence of "Number of diffs are incorrect" failures in `ci-results-repo.yml`
- [ ] Confirm `ci.yml` jobs still validate correctly (local `gh-pages` branch with `skip-fetch-gh-pages: true` flow unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflows to fetch benchmark baselines before runs and validate results after runs.
  * Switched validation to use Git-backed comparisons for before/after benchmark data.
  * Added stricter post-run checks (commit/message/author) and more robust error handling/logging.
  * Broadened automatic validation coverage across many benchmark types and simplified invocation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->