### PR TITLE
perf: shallow-clone the target branch only

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -152,17 +152,3 @@ export async function clone(
 
     return cmd(additionalGitOptions, ...args);
 }
-export async function checkout(
-    ghRef: string,
-    additionalGitOptions: string[] = [],
-    ...options: string[]
-): Promise<string> {
-    core.debug(`Executing 'git checkout' to ref '${ghRef}' with token and options '${options.join(' ')}'`);
-
-    let args = ['checkout', ghRef];
-    if (options.length > 0) {
-        args = args.concat(options);
-    }
-
-    return cmd(additionalGitOptions, ...args);
-}

--- a/src/write.ts
+++ b/src/write.ts
@@ -367,12 +367,21 @@ async function writeBenchmarkToGitHubPagesWithRetry(
 
     if (githubToken && !skipFetchGhPages && ghRepository) {
         benchmarkBaseDir = './benchmark-data-repository';
-        await git.clone(githubToken, ghRepository, benchmarkBaseDir);
+        await git.clone(
+            githubToken,
+            ghRepository,
+            benchmarkBaseDir,
+            [],
+            '--branch',
+            ghPagesBranch,
+            '--single-branch',
+            '--depth',
+            '1',
+        );
         rollbackActions.push(async () => {
             await io.rmRF(benchmarkBaseDir);
         });
         extraGitArguments = [`--work-tree=${benchmarkBaseDir}`, `--git-dir=${benchmarkBaseDir}/.git`];
-        await git.checkout(ghPagesBranch, extraGitArguments);
     } else if (!skipFetchGhPages && (!isPrivateRepo || githubToken)) {
         await git.pull(githubToken, ghPagesBranch);
     } else if (isPrivateRepo && !skipFetchGhPages) {

--- a/test/write.spec.ts
+++ b/test/write.spec.ts
@@ -21,7 +21,7 @@ const ok: (x: any, msg?: string) => asserts x = (x, msg) => {
     }
 };
 
-type GitFunc = 'cmd' | 'push' | 'pull' | 'fetch' | 'clone' | 'checkout';
+type GitFunc = 'cmd' | 'push' | 'pull' | 'fetch' | 'clone';
 class GitSpy {
     history: [GitFunc, unknown[]][];
     pushFailure: null | string;
@@ -108,10 +108,6 @@ jest.mock('../src/git', () => ({
     },
     async clone(...args: unknown[]) {
         gitSpy.call('clone', args);
-        return '';
-    },
-    async checkout(...args: unknown[]) {
-        gitSpy.call('checkout', args);
         return '';
     },
 }));
@@ -1088,12 +1084,18 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 },
                 gitServerUrl: serverUrl,
                 gitHistory: [
-                    ['clone', ['dummy token', 'https://github.com/user/other-repo', './benchmark-data-repository']],
                     [
-                        'checkout',
+                        'clone',
                         [
+                            'dummy token',
+                            'https://github.com/user/other-repo',
+                            './benchmark-data-repository',
+                            [],
+                            '--branch',
                             'gh-pages',
-                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                            '--single-branch',
+                            '--depth',
+                            '1',
                         ],
                     ],
                     [
@@ -1147,12 +1149,18 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 },
                 gitServerUrl: serverUrl,
                 gitHistory: [
-                    ['clone', ['dummy token', 'https://github.com/user/other-repo', './benchmark-data-repository']],
                     [
-                        'checkout',
+                        'clone',
                         [
+                            'dummy token',
+                            'https://github.com/user/other-repo',
+                            './benchmark-data-repository',
+                            [],
+                            '--branch',
                             'gh-pages',
-                            ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
+                            '--single-branch',
+                            '--depth',
+                            '1',
                         ],
                     ],
                     [


### PR DESCRIPTION
This PR modifies the action to shallow clone the target branch only. 

**Why**: For large repos, the time to do a full clone and checkout can be 20 minutes plus, which is long enough to cause retry loops when the branch tip is under contention by multiple benchmark runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Benchmark repositories are now retrieved using a faster, shallow clone of only the required GitHub Pages branch.
  * Removed the separate branch checkout step during benchmark publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->